### PR TITLE
Add support for modin dataframes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -117,8 +117,8 @@ jobs:
     - name: Uninstall unavailable dependencies
       # Disables modin and Ray Tune (via tabulate)
       run: |
-        python -m pip uninstall modin || true
-        python -m pip uninstall tabulate || true
+        python -m pip uninstall -y modin
+        python -m pip uninstall -y tabulate
     - name: Install package
       run: |
         python -m pip install -e .

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -95,3 +95,45 @@ jobs:
         echo "running simple_tune.py" && python simple_tune.py --smoke-test
         echo "running train_on_test_data.py" && python train_on_test_data.py --smoke-test
       # for f in *.py; do echo "running $f" && python "$f" || exit 1 ; done
+
+  test_linux_compat:
+    # Test compatibility when some optional libraries are missing
+    # Test runs on latest ray release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install codecov
+        python -m pip install -U ray
+        if [ -f requirements-test.txt ]; then python -m pip install -r requirements-test.txt; fi
+    - name: Uninstall unavailable dependencies
+      # Disables modin and Ray Tune (via tabulate)
+      run: |
+        python -m pip uninstall modin || true
+        python -m pip uninstall tabulate || true
+    - name: Install package
+      run: |
+        python -m pip install -e .
+    - name: Test with pytest
+      run: |
+        pushd xgboost_ray/tests
+        python -m pytest -v --durations=0 -x test_matrix.py
+        python -m pytest -v --durations=0 -x test_xgboost_api.py
+        python -m pytest -v --durations=0 -x test_fault_tolerance.py
+        python -m pytest -v --durations=0 -x test_end_to_end.py
+        echo "running smoke test on benchmark_cpu_gpu.py" && python release/benchmark_cpu_gpu.py 2 10 20 --smoke-test
+        popd
+        pushd examples/
+        ray stop || true
+        echo "running simple.py" && python simple.py --smoke-test
+        echo "running simple_predict.py" && python simple_predict.py
+        echo "running train_on_test_data.py" && python train_on_test_data.py --smoke-test
+      # for f in *.py; do echo "running $f" && python "$f" || exit 1 ; done

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,3 +6,4 @@ pytest
 pyarrow
 ray[tune]
 scikit-learn
+modin[ray]

--- a/xgboost_ray/matrix.py
+++ b/xgboost_ray/matrix.py
@@ -20,10 +20,7 @@ import ray
 try:
     from ray.util.data import MLDataset
 except ImportError:
-
-    class MLDataset:
-        pass
-
+    MLDataset = object
 
 from xgboost.core import DataIter
 
@@ -432,9 +429,6 @@ class _DistributedRayDMatrixLoader(_RayDMatrixLoader):
             x, y, w, b, ll, lu = self._load_data_csv(local_input_sources)
         elif self.filetype == RayFileType.PARQUET:
             x, y, w, b, ll, lu = self._load_data_parquet(local_input_sources)
-        elif self.filetype == RayFileType.ML_DATASET:
-            x, y, w, b, ll, lu = self._load_data_ml_dataset(
-                local_input_sources)
         else:
             raise ValueError(
                 "Invalid data source type: {} with FileType: {} for a "

--- a/xgboost_ray/matrix.py
+++ b/xgboost_ray/matrix.py
@@ -17,10 +17,12 @@ import os
 
 import ray
 
+from xgboost_ray.util import Unavailable
+
 try:
     from ray.util.data import MLDataset
 except ImportError:
-    MLDataset = object
+    MLDataset = Unavailable
 
 try:
     import modin  # noqa: F401

--- a/xgboost_ray/matrix.py
+++ b/xgboost_ray/matrix.py
@@ -526,10 +526,11 @@ class RayDMatrix:
 
     Args:
         data: Data object. Can be a pandas dataframe, pandas series,
-            numpy array, string pointing to a csv or parquet file, or
-            list of strings pointing to csv or parquet files.
-        label: Optional label object. Can be a pandas series,
-            numpy array, string pointing to a csv or parquet file, or
+            numpy array, Ray MLDataset, modin dataframe, string pointing to
+            a csv or parquet file, or list of strings pointing to csv or
+            parquet files.
+        label: Optional label object. Can be a pandas series, numpy array,
+            modin series, string pointing to a csv or parquet file, or
             a string indicating the column of the data dataframe that
             contains the label. If this is not a string it must be of the
             same type as the data argument.

--- a/xgboost_ray/tests/test_matrix.py
+++ b/xgboost_ray/tests/test_matrix.py
@@ -79,7 +79,7 @@ class XGBoostRayDMatrixTest(unittest.TestCase):
 
     def testFromModinDfDf(self):
         try:
-            from modin.pandas import DataFrame, Series
+            from modin.pandas import DataFrame
         except ImportError:
             self.skipTest("Modin not installed.")
             return
@@ -101,7 +101,7 @@ class XGBoostRayDMatrixTest(unittest.TestCase):
 
     def testFromModinDfString(self):
         try:
-            from modin.pandas import DataFrame, Series
+            from modin.pandas import DataFrame
         except ImportError:
             self.skipTest("Modin not installed.")
             return

--- a/xgboost_ray/tests/test_matrix.py
+++ b/xgboost_ray/tests/test_matrix.py
@@ -189,12 +189,6 @@ class XGBoostRayDMatrixTest(unittest.TestCase):
             self._testMatrixCreation(dataset, "label", distributed=True)
 
     def testDetectDistributed(self):
-        try:
-            from ray.util import data as ml_data
-        except ImportError:
-            self.skipTest("MLDataset not available in current Ray version.")
-            return
-
         with tempfile.TemporaryDirectory() as dir:
             data_file = os.path.join(dir, "file.parquet")
 
@@ -209,9 +203,14 @@ class XGBoostRayDMatrixTest(unittest.TestCase):
             mat = RayDMatrix([data_file] * 3, lazy=True)
             self.assertTrue(mat.distributed)
 
-            mat = RayDMatrix(
-                ml_data.read_parquet(data_file, num_shards=1), lazy=True)
-            self.assertTrue(mat.distributed)
+            try:
+                from ray.util import data as ml_data
+                mat = RayDMatrix(
+                    ml_data.read_parquet(data_file, num_shards=1), lazy=True)
+                self.assertTrue(mat.distributed)
+            except ImportError:
+                print("MLDataset not available in current Ray version. "
+                      "Skipping part of test.")
 
 
 if __name__ == "__main__":

--- a/xgboost_ray/tests/test_matrix.py
+++ b/xgboost_ray/tests/test_matrix.py
@@ -77,6 +77,39 @@ class XGBoostRayDMatrixTest(unittest.TestCase):
         in_df["label"] = self.y
         self._testMatrixCreation(in_df, "label")
 
+    def testFromModinDfDf(self):
+        try:
+            from modin.pandas import DataFrame, Series
+        except ImportError:
+            self.skipTest("Modin not installed.")
+            return
+
+        in_x = DataFrame(self.x)
+        in_y = DataFrame(self.y)
+        self._testMatrixCreation(in_x, in_y)
+
+    def testFromModinDfSeries(self):
+        try:
+            from modin.pandas import DataFrame, Series
+        except ImportError:
+            self.skipTest("Modin not installed.")
+            return
+
+        in_x = DataFrame(self.x)
+        in_y = Series(self.y)
+        self._testMatrixCreation(in_x, in_y)
+
+    def testFromModinDfString(self):
+        try:
+            from modin.pandas import DataFrame, Series
+        except ImportError:
+            self.skipTest("Modin not installed.")
+            return
+
+        in_df = DataFrame(self.x)
+        in_df["label"] = self.y
+        self._testMatrixCreation(in_df, "label")
+
     def testFromCSVString(self):
         with tempfile.TemporaryDirectory() as dir:
             data_file = os.path.join(dir, "data.csv")

--- a/xgboost_ray/util.py
+++ b/xgboost_ray/util.py
@@ -4,6 +4,13 @@ import asyncio
 from ray.util.queue import Queue as RayQueue
 
 
+class Unavailable:
+    """No object should be instance of this class"""
+
+    def __init__(self):
+        raise RuntimeError("This class should never be instantiated.")
+
+
 @ray.remote
 class _EventActor:
     def __init__(self):


### PR DESCRIPTION
Currently only in central data loading mode. Integration with distributed mode would require more access to private modin functions - we can look into this at another time.

This PR also adds (and fixes) compatibility tests for the latest ray release when some dependencies are not installed. E.g. if Tune or Modin are not installed, certain tests and examples should still run.