### PR TITLE
Tune reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 Distributed XGBoost on Ray
 ==========================
+![Build Status](https://github.com/ray-project/xgboost_ray/workflows/pytest%20on%20push/badge.svg)
 
 This library adds a new backend for XGBoost utilizing the
 [distributed computing framework Ray](https://ray.io).
 
-Please note that this is an early version and both the API and
-the behavior can change without prior notice.
+XGBoost on Ray enables multi node and multi GPU 
+training with an interface compatible with the usual
+XGBoost API. It also integrates with [Ray Tune](#hyperparameter-tuning)
+and offers advanced fault tolerance configuration.
 
-We'll switch to a release-based development process once the
-implementation has all features for first real world use cases.
+All releases are tested on large clusters and workloads.
+
 
 Installation
 ------------

--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -511,9 +511,11 @@ def _autodetect_resources(ray_params: RayParams,
     # actors, bounded by the minimum number of CPUs across actors nodes.
     if cpus_per_actor <= 0:
         cluster_cpus = _ray_get_cluster_cpus() or 1
-        cpus_per_actor = min(
-            int(_get_min_node_cpus() or 1),
-            int(cluster_cpus // ray_params.num_actors))
+        cpus_per_actor = max(
+            1,
+            min(
+                int(_get_min_node_cpus() or 1),
+                int(cluster_cpus // ray_params.num_actors)))
     return cpus_per_actor, gpus_per_actor
 
 

--- a/xgboost_ray/tests/test_tune.py
+++ b/xgboost_ray/tests/test_tune.py
@@ -65,7 +65,7 @@ class XGBoostRayTuneTest(unittest.TestCase):
 
     # noinspection PyTypeChecker
     def testNumIters(self):
-        ray_params = RayParams(cpus_per_actor=1, num_actors=1)
+        ray_params = RayParams(cpus_per_actor=1, num_actors=2)
         analysis = tune.run(
             self.train_func(ray_params),
             config=self.params,
@@ -75,9 +75,9 @@ class XGBoostRayTuneTest(unittest.TestCase):
             },
             num_samples=2)
 
-        self.assertTrue(
-            all(analysis.results_df["training_iteration"] ==
-                analysis.results_df["config.num_boost_round"]))
+        self.assertSequenceEqual(
+            list(analysis.results_df["training_iteration"]),
+            list(analysis.results_df["config.num_boost_round"]))
 
     def testElasticFails(self):
         """Test if error is thrown when using Tune with elastic training."""


### PR DESCRIPTION
Currently, we are reporting results from every actor. This leads to a double reports and a blown up iteration count. Instead, we should just report results from the 0 rank actor.
