### PR TITLE
fix colocation test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 Distributed XGBoost on Ray
 ==========================
+![Build Status](https://github.com/ray-project/xgboost_ray/workflows/pytest%20on%20push/badge.svg)
 
 This library adds a new backend for XGBoost utilizing the
 [distributed computing framework Ray](https://ray.io).
 
-Please note that this is an early version and both the API and
-the behavior can change without prior notice.
+XGBoost on Ray enables multi node and multi GPU 
+training with an interface compatible with the usual
+XGBoost API. It also integrates with [Ray Tune](#hyperparameter-tuning)
+and offers advanced fault tolerance configuration.
 
-We'll switch to a release-based development process once the
-implementation has all features for first real world use cases.
+All releases are tested on large clusters and workloads.
+
 
 Installation
 ------------

--- a/xgboost_ray/tests/test_colocation.py
+++ b/xgboost_ray/tests/test_colocation.py
@@ -1,5 +1,3 @@
-import datetime
-import logging
 import os
 import shutil
 import tempfile
@@ -63,9 +61,6 @@ class TestColocation(unittest.TestCase):
     @patch("xgboost_ray.util._EventActor", _MockEventActor)
     def test_communication_colocation(self):
         """Checks that Queue and Event actors are colocated with the driver."""
-        logging.basicConfig(format="%(asctime)s\t%(levelname)s %(filename)s:"
-                            "%(lineno)s -- %(message)s")
-        print("Start test_communication_colocation")
         with self.ray_start_cluster() as cluster:
             cluster.add_node(num_cpus=3)
             cluster.add_node(num_cpus=3)
@@ -84,25 +79,18 @@ class TestColocation(unittest.TestCase):
                 assert ray.get(
                     _training_state.stop_event.actor.get_node_id.remote()) == \
                     ray.state.current_node_id()
-                print(f"Calling _train at {datetime.datetime.now()}")
-                logging.info(f"Calling _train at {datetime.datetime.now()}")
                 return DEFAULT, DEFAULT, DEFAULT
 
             with patch("xgboost_ray.main._train") as mocked:
                 mocked.side_effect = _mock_train
-                print(f"Calling train at {datetime.datetime.now()}")
-                logging.info(f"Calling train at {datetime.datetime.now()}")
                 train(
                     self.params,
                     RayDMatrix(self.x, self.y),
                     num_boost_round=2,
                     ray_params=RayParams(max_actor_restarts=1, num_actors=6))
-        logging.info(f"Passed train at {datetime.datetime.now()}")
-        print(f"Passed train at {datetime.datetime.now()}")
 
     def test_no_tune_spread(self):
         """Tests whether workers are spread when not using Tune."""
-        print("Start test_no_tune_spread")
         with self.ray_start_cluster() as cluster:
             cluster.add_node(num_cpus=2)
             cluster.add_node(num_cpus=2)
@@ -138,7 +126,6 @@ class TestColocation(unittest.TestCase):
                     ray_params=ray_params)
 
     def test_tune_pack(self):
-        print("Start test_tune_pack")
         """Tests whether workers are packed when using Tune."""
         try:
             from ray import tune

--- a/xgboost_ray/tests/test_colocation.py
+++ b/xgboost_ray/tests/test_colocation.py
@@ -4,7 +4,7 @@ import os
 import shutil
 import tempfile
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, DEFAULT
 import pytest
 
 import numpy as np
@@ -85,9 +85,10 @@ class TestColocation(unittest.TestCase):
                     ray.state.current_node_id()
                 print(f"Calling _train at {datetime.datetime.now()}")
                 logging.info(f"Calling _train at {datetime.datetime.now()}")
-                return _train(*args, _training_state=_training_state, **kwargs)
+                return DEFAULT, DEFAULT, DEFAULT
 
-            with patch("xgboost_ray.main._train", _mock_train):
+            with patch("xgboost_ray.main._train") as mocked:
+                mocked.side_effect = _mock_train
                 print(f"Calling train at {datetime.datetime.now()}")
                 logging.info(f"Calling train at {datetime.datetime.now()}")
                 train(

--- a/xgboost_ray/tests/test_colocation.py
+++ b/xgboost_ray/tests/test_colocation.py
@@ -69,6 +69,7 @@ class TestColocation(unittest.TestCase):
         with self.ray_start_cluster() as cluster:
             cluster.add_node(num_cpus=3)
             cluster.add_node(num_cpus=3)
+            cluster.wait_for_nodes()
             ray.init(address=cluster.address)
 
             local_node = ray.state.current_node_id()
@@ -105,6 +106,7 @@ class TestColocation(unittest.TestCase):
         with self.ray_start_cluster() as cluster:
             cluster.add_node(num_cpus=2)
             cluster.add_node(num_cpus=2)
+            cluster.wait_for_nodes()
             ray.init(address=cluster.address)
 
             ray_params = RayParams(

--- a/xgboost_ray/tests/test_colocation.py
+++ b/xgboost_ray/tests/test_colocation.py
@@ -63,7 +63,8 @@ class TestColocation(unittest.TestCase):
     @patch("xgboost_ray.util._EventActor", _MockEventActor)
     def test_communication_colocation(self):
         """Checks that Queue and Event actors are colocated with the driver."""
-        logging.basicConfig(format="%(asctime)s\t%(levelname)s %(filename)s:%(lineno)s -- %(message)s")
+        logging.basicConfig(format="%(asctime)s\t%(levelname)s %(filename)s:"
+                            "%(lineno)s -- %(message)s")
         print("Start test_communication_colocation")
         with self.ray_start_cluster() as cluster:
             cluster.add_node(num_cpus=3)


### PR DESCRIPTION
It seems that indeed the second test is started prematurely. The output is misleading.

Waiting for cluster nodes to be ready seems to be at the core of this problem, and it should be safe to do this in any case.