### PR TITLE
Fix RayDeviceQuantileDMatrix

### DIFF
--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -215,8 +215,6 @@ def _get_dmatrix(data: RayDMatrix, param: Dict) -> xgb.DMatrix:
                 "feature_types": data.feature_types,
                 "missing": data.missing,
             }
-            if not isinstance(data, xgb.DeviceQuantileDMatrix):
-                pass
             param.update(dm_param)
             it = RayDataIter(**param)
             matrix = xgb.DeviceQuantileDMatrix(it, **dm_param)
@@ -432,7 +430,10 @@ class RayXGBoostActor:
             if num_threads > 0:
                 local_params["num_threads"] = num_threads
             else:
-                local_params["nthread"] = ray.utils.get_num_cpus()
+                try:
+                    local_params["nthread"] = ray._private.utils.get_num_cpus()
+                except AttributeError:
+                    local_params["nthread"] = ray.utils.get_num_cpus()
 
         if dtrain not in self._data:
             self.load_data(dtrain)

--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -212,17 +212,17 @@ def _get_dmatrix(data: RayDMatrix, param: Dict) -> xgb.DMatrix:
         # If we only got a single data shard, create a list so we can
         # iterate over it
         if not isinstance(param["data"], list):
-            param["data"] = param["data"]
+            param["data"] = [param["data"]]
 
             if not isinstance(param["label"], list):
-                param["label"] = param["label"]
+                param["label"] = [param["label"]]
             if not isinstance(param["weight"], list):
-                param["weight"] = param["weight"]
+                param["weight"] = [param["weight"]]
             if not isinstance(param["data"], list):
-                param["base_margin"] = param["base_margin"]
+                param["base_margin"] = [param["base_margin"]]
 
-        param["label_lower_bound"] = None
-        param["label_upper_bound"] = None
+        param["label_lower_bound"] = [None]
+        param["label_upper_bound"] = [None]
 
         dm_param = {
             "feature_names": data.feature_names,

--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -221,12 +221,13 @@ def _get_dmatrix(data: RayDMatrix, param: Dict) -> xgb.DMatrix:
             if not isinstance(param["data"], list):
                 param["base_margin"] = param["base_margin"]
 
+        param["label_lower_bound"] = None
+        param["label_upper_bound"] = None
+
         dm_param = {
             "feature_names": data.feature_names,
             "feature_types": data.feature_types,
             "missing": data.missing,
-            "label_lower_bound": None,
-            "label_upper_bound": None,
         }
         param.update(dm_param)
         it = RayDataIter(**param)

--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -442,10 +442,8 @@ class RayXGBoostActor:
             if num_threads > 0:
                 local_params["num_threads"] = num_threads
             else:
-                try:
-                    local_params["nthread"] = ray._private.utils.get_num_cpus()
-                except AttributeError:
-                    local_params["nthread"] = ray.utils.get_num_cpus()
+                local_params["nthread"] = sum(
+                    num for _, num in ray.get_resource_ids().get("CPU", []))
 
         if dtrain not in self._data:
             self.load_data(dtrain)

--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -225,6 +225,8 @@ def _get_dmatrix(data: RayDMatrix, param: Dict) -> xgb.DMatrix:
             "feature_names": data.feature_names,
             "feature_types": data.feature_types,
             "missing": data.missing,
+            "label_lower_bound": None,
+            "label_upper_bound": None,
         }
         param.update(dm_param)
         it = RayDataIter(**param)

--- a/xgboost_ray/matrix.py
+++ b/xgboost_ray/matrix.py
@@ -653,7 +653,8 @@ class RayDeviceQuantileDMatrix(RayDMatrix):
         if cp is None:
             raise RuntimeError(
                 "RayDeviceQuantileDMatrix requires cupy to be installed."
-                "\nFIX THIS by installing cupy: `pip install cupy`")
+                "\nFIX THIS by installing cupy: `pip install cupy-cudaXYZ` "
+                "where XYZ is your local CUDA version.")
         if label_lower_bound or label_upper_bound:
             raise RuntimeError(
                 "RayDeviceQuantileDMatrix does not support "


### PR DESCRIPTION
RayDeviceQuantileDMatrix became incompatible with recent changes. This PR makes sure it works again.

Please note that we currently have no general support to load from files into GPU memory directly, avoiding CPU memory. Thus the RayDeviceQuantileDMatrix works with conversion (or when cupy arrays are provided directly). In the future we might want to introduce interfaces for loading from files into GPU memory.

Closes #65