### PR TITLE
Add distributed callback interface to RayXGBoostActor

### DIFF
--- a/xgboost_ray/callback.py
+++ b/xgboost_ray/callback.py
@@ -1,0 +1,89 @@
+from abc import ABC
+from typing import Dict, Sequence, TYPE_CHECKING
+
+import pandas as pd
+
+if TYPE_CHECKING:
+    from xgboost_ray.main import RayXGBoostActor
+    from xgboost_ray.matrix import RayDMatrix
+
+
+class DistributedCallback(ABC):
+    """Distributed callbacks for RayXGBoostActors.
+
+    The hooks of these callbacks are executed on the remote Ray actors
+    at different points in time. They can be used to set environment
+    variables or to prepare the training/prediction environment in other
+    ways. Distributed callback objects are de-serialized on each actor
+    and are then independent of each other - changing the state of one
+    callback will not alter the state of the other copies on different actors.
+
+    Callbacks can be passed to xgboost_ray via
+    :class:`RayParams <xgboost_ray.main.RayParams>` using the
+    ``distributed_callbacks`` parameter.
+    """
+
+    def __init__(self):
+        pass
+
+    def on_init(self, actor: "RayXGBoostActor", *args, **kwargs):
+        pass
+
+    def before_data_loading(self, actor: "RayXGBoostActor", data: "RayDMatrix",
+                            *args, **kwargs):
+        pass
+
+    def after_data_loading(self, actor: "RayXGBoostActor", data: "RayDMatrix",
+                           *args, **kwargs):
+        pass
+
+    def before_train(self, actor: "RayXGBoostActor", *args, **kwargs):
+        pass
+
+    def after_train(self, actor: "RayXGBoostActor", result_dict: Dict, *args,
+                    **kwargs):
+        pass
+
+    def before_predict(self, actor: "RayXGBoostActor", *args, **kwargs):
+        pass
+
+    def after_predict(self, actor: "RayXGBoostActor", predictions: pd.Series,
+                      *args, **kwargs):
+        pass
+
+
+class DistributedCallbackContainer:
+    def __init__(self, callbacks: Sequence[DistributedCallback]):
+        self.callbacks = callbacks or []
+
+    def on_init(self, actor: "RayXGBoostActor", *args, **kwargs):
+        for callback in self.callbacks:
+            callback.on_init(actor, *args, **kwargs)
+
+    def before_data_loading(self, actor: "RayXGBoostActor", data: "RayDMatrix",
+                            *args, **kwargs):
+        for callback in self.callbacks:
+            callback.before_data_loading(actor, data, *args, **kwargs)
+
+    def after_data_loading(self, actor: "RayXGBoostActor", data: "RayDMatrix",
+                           *args, **kwargs):
+        for callback in self.callbacks:
+            callback.after_data_loading(actor, data, *args, **kwargs)
+
+    def before_train(self, actor: "RayXGBoostActor", *args, **kwargs):
+        for callback in self.callbacks:
+            callback.before_train(actor, *args, **kwargs)
+
+    def after_train(self, actor: "RayXGBoostActor", result_dict: Dict, *args,
+                    **kwargs):
+        for callback in self.callbacks:
+            callback.after_train(actor, result_dict, *args, **kwargs)
+
+    def before_predict(self, actor: "RayXGBoostActor", *args, **kwargs):
+        for callback in self.callbacks:
+            callback.before_predict(actor, *args, **kwargs)
+
+    def after_predict(self, actor: "RayXGBoostActor", predictions: pd.Series,
+                      *args, **kwargs):
+        for callback in self.callbacks:
+            callback.after_predict(actor, predictions, *args, **kwargs)

--- a/xgboost_ray/callback.py
+++ b/xgboost_ray/callback.py
@@ -23,9 +23,6 @@ class DistributedCallback(ABC):
     ``distributed_callbacks`` parameter.
     """
 
-    def __init__(self):
-        pass
-
     def on_init(self, actor: "RayXGBoostActor", *args, **kwargs):
         pass
 

--- a/xgboost_ray/elastic.py
+++ b/xgboost_ray/elastic.py
@@ -57,7 +57,8 @@ def _maybe_schedule_new_actors(
             resources_per_actor=resources_per_actor,
             placement_group=training_state.placement_group,
             queue=training_state.queue,
-            checkpoint_frequency=ray_params.checkpoint_frequency)
+            checkpoint_frequency=ray_params.checkpoint_frequency,
+            distributed_callbacks=ray_params.distributed_callbacks)
 
         task = _PrepareActorTask(
             actor,

--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -430,10 +430,10 @@ class RayXGBoostActor:
         return _StopCallback()
 
     def load_data(self, data: RayDMatrix):
-        self._distributed_callbacks.before_data_loading(self, data)
-
         if data in self._data:
             return
+
+        self._distributed_callbacks.before_data_loading(self, data)
 
         param = data.get_data(self.rank, self.num_actors)
         if isinstance(param["data"], list):

--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -430,10 +430,10 @@ class RayXGBoostActor:
         return _StopCallback()
 
     def load_data(self, data: RayDMatrix):
+        self._distributed_callbacks.before_data_loading(self, data)
+
         if data in self._data:
             return
-
-        self._distributed_callbacks.before_data_loading(self, data)
 
         param = data.get_data(self.rank, self.num_actors)
         if isinstance(param["data"], list):

--- a/xgboost_ray/tests/test_end_to_end.py
+++ b/xgboost_ray/tests/test_end_to_end.py
@@ -1,3 +1,7 @@
+import os
+import shutil
+import tempfile
+
 import numpy as np
 import unittest
 import xgboost as xgb
@@ -5,7 +9,45 @@ import xgboost as xgb
 import ray
 
 from xgboost_ray import RayParams, train, RayDMatrix, predict
+from xgboost_ray.callback import DistributedCallback
 from xgboost_ray.tests.utils import get_num_trees
+
+
+def _make_callback(tmpdir: str) -> DistributedCallback:
+    class TestDistributedCallback(DistributedCallback):
+        logdir = tmpdir
+
+        def on_init(self, actor, *args, **kwargs):
+            log_file = os.path.join(self.logdir, f"rank_{actor.rank}.log")
+            actor.log_fp = open(log_file, "at")
+            actor.log_fp.write(f"Actor {actor.rank}: Init\n")
+            actor.log_fp.flush()
+
+        def before_data_loading(self, actor, data, *args, **kwargs):
+            actor.log_fp.write(f"Actor {actor.rank}: Before loading\n")
+            actor.log_fp.flush()
+
+        def after_data_loading(self, actor, data, *args, **kwargs):
+            actor.log_fp.write(f"Actor {actor.rank}: After loading\n")
+            actor.log_fp.flush()
+
+        def before_train(self, actor, *args, **kwargs):
+            actor.log_fp.write(f"Actor {actor.rank}: Before train\n")
+            actor.log_fp.flush()
+
+        def after_train(self, actor, result_dict, *args, **kwargs):
+            actor.log_fp.write(f"Actor {actor.rank}: After train\n")
+            actor.log_fp.flush()
+
+        def before_predict(self, actor, *args, **kwargs):
+            actor.log_fp.write(f"Actor {actor.rank}: Before predict\n")
+            actor.log_fp.flush()
+
+        def after_predict(self, actor, predictions, *args, **kwargs):
+            actor.log_fp.write(f"Actor {actor.rank}: After predict\n")
+            actor.log_fp.flush()
+
+    return TestDistributedCallback()
 
 
 class XGBoostRayEndToEndTest(unittest.TestCase):
@@ -104,7 +146,7 @@ class XGBoostRayEndToEndTest(unittest.TestCase):
         pred_y = bst.predict(x_mat)
         self.assertSequenceEqual(list(self.y), list(pred_y))
 
-    def testTrainPredict(self, init=True, remote=None):
+    def testTrainPredict(self, init=True, remote=None, **ray_param_dict):
         """Train with evaluation and predict"""
         if init:
             ray.init(num_cpus=2, num_gpus=0)
@@ -116,7 +158,7 @@ class XGBoostRayEndToEndTest(unittest.TestCase):
             self.params,
             dtrain,
             num_boost_round=38,
-            ray_params=RayParams(num_actors=2),
+            ray_params=RayParams(num_actors=2, **ray_param_dict),
             evals=[(dtrain, "dtrain")],
             evals_result=evals_result,
             _remote=remote)
@@ -126,7 +168,11 @@ class XGBoostRayEndToEndTest(unittest.TestCase):
         self.assertTrue("dtrain" in evals_result)
 
         x_mat = RayDMatrix(self.x)
-        pred_y = predict(bst, x_mat, _remote=remote)
+        pred_y = predict(
+            bst,
+            x_mat,
+            ray_params=RayParams(num_actors=2, **ray_param_dict),
+            _remote=remote)
         self.assertSequenceEqual(list(self.y), list(pred_y))
 
     def testTrainPredictRemote(self):
@@ -145,6 +191,45 @@ class XGBoostRayEndToEndTest(unittest.TestCase):
             self.assertTrue(ray.util.client.ray.is_connected())
 
             self.testTrainPredict(init=False, remote=None)
+
+    def testDistributedCallbacksTrainPredict(self, init=True, remote=False):
+        """Test distributed callbacks for train/predict"""
+        tmpdir = tempfile.mkdtemp()
+        test_callback = _make_callback(tmpdir)
+
+        self.testTrainPredict(
+            init=init, remote=remote, distributed_callbacks=[test_callback])
+        rank_0_log_file = os.path.join(tmpdir, "rank_0.log")
+        rank_1_log_file = os.path.join(tmpdir, "rank_1.log")
+        self.assertTrue(os.path.exists(rank_1_log_file))
+
+        rank_0_log = open(rank_0_log_file, "rt").read()
+        self.assertEqual(
+            rank_0_log, "Actor 0: Init\n"
+            "Actor 0: Before loading\n"
+            "Actor 0: After loading\n"
+            "Actor 0: Before train\n"
+            "Actor 0: After train\n"
+            "Actor 0: Init\n"
+            "Actor 0: Before loading\n"
+            "Actor 0: After loading\n"
+            "Actor 0: Before predict\n"
+            "Actor 0: After predict\n")
+        shutil.rmtree(tmpdir)
+
+    def testDistributedCallbacksTrainPredictClient(self):
+        """Test distributed callbacks for train/predict via Ray client"""
+
+        if ray.__version__ <= "1.2.0":
+            self.skipTest("Ray client mocks do not work in Ray <= 1.2.0")
+        from ray.util.client.ray_client_helpers import ray_start_client_server
+
+        ray.init(num_cpus=2, num_gpus=0)
+        self.assertFalse(ray.util.client.ray.is_connected())
+        with ray_start_client_server():
+            self.assertTrue(ray.util.client.ray.is_connected())
+
+            self.testDistributedCallbacksTrainPredict(init=False, remote=None)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds a callback interface to RayXGBoostActor. This has been a request in #49 and we'll use it for more fine-grained fault tolerance testing - we can e.g. control when actors are allowed to come back after they terminated.

The parameter and class are called "distributed callback" to set them apart from the regular xgboost training callbacks.

Closes #49 