### PR TITLE
Fix local n calculation

### DIFF
--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -363,7 +363,7 @@ class RayXGBoostActor:
         self.checkpoint_frequency = checkpoint_frequency
 
         self._data: Dict[RayDMatrix, xgb.DMatrix] = {}
-        self._local_n = 0
+        self._local_n: Dict[RayDMatrix, int] = {}
 
         self._stop_event = stop_event
 
@@ -437,9 +437,9 @@ class RayXGBoostActor:
 
         param = data.get_data(self.rank, self.num_actors)
         if isinstance(param["data"], list):
-            self._local_n = sum(len(a) for a in param["data"])
+            self._local_n[data] = sum(len(a) for a in param["data"])
         else:
-            self._local_n = len(param["data"])
+            self._local_n[data] = len(param["data"])
         data.unload_data()  # Free object store
 
         matrix = _get_dmatrix(data, param)
@@ -511,7 +511,7 @@ class RayXGBoostActor:
                     result_dict.update({
                         "bst": bst,
                         "evals_result": evals_result,
-                        "train_n": self._local_n
+                        "train_n": self._local_n[dtrain]
                     })
             except XGBoostError:
                 # Silent fail, will be raised as RayXGBoostTrainingStopped


### PR DESCRIPTION
Currently the actor local n is overridden when loading any data. This means that usually the length of the last evaluation dataset is returned instead of the last training dataset.