### PR TITLE
Raise an error if actors would end up without any data

### DIFF
--- a/xgboost_ray/data_sources/csv.py
+++ b/xgboost_ray/data_sources/csv.py
@@ -39,3 +39,7 @@ class CSV(DataSource):
         else:
             local_df = pd.read_csv(data, **kwargs)
             return Pandas.load_data(local_df, ignore=ignore)
+
+    @staticmethod
+    def get_n(data: Any):
+        return len(list(data))

--- a/xgboost_ray/data_sources/data_source.py
+++ b/xgboost_ray/data_sources/data_source.py
@@ -111,7 +111,7 @@ class DataSource:
     @staticmethod
     def get_n(data: Any):
         """Get length of data source partitions for sharding."""
-        return len(list(data))
+        return len(data)
 
     @staticmethod
     def get_actor_shards(

--- a/xgboost_ray/data_sources/parquet.py
+++ b/xgboost_ray/data_sources/parquet.py
@@ -40,3 +40,7 @@ class Parquet(DataSource):
         else:
             local_df = pd.read_parquet(data, **kwargs)
             return Pandas.load_data(local_df, ignore=ignore)
+
+    @staticmethod
+    def get_n(data: Any):
+        return len(list(data))

--- a/xgboost_ray/data_sources/petastorm.py
+++ b/xgboost_ray/data_sources/petastorm.py
@@ -73,3 +73,7 @@ class Petastorm(DataSource):
             local_df = local_df[local_df.columns.difference(ignore)]
 
         return local_df
+
+    @staticmethod
+    def get_n(data: Any):
+        return len(list(data))

--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -820,8 +820,10 @@ def _train(params: Dict,
 
     # For distributed datasets (e.g. Modin), this will initialize
     # (and fix) the assignment of data shards to actor ranks
+    dtrain.assert_enough_shards_for_actors(num_actors=ray_params.num_actors)
     dtrain.assign_shards_to_actors(_training_state.actors)
     for deval, _ in evals:
+        deval.assert_enough_shards_for_actors(num_actors=ray_params.num_actors)
         deval.assign_shards_to_actors(_training_state.actors)
 
     load_data = [dtrain] + [eval[0] for eval in evals]
@@ -870,9 +872,9 @@ def _train(params: Dict,
         if _training_state.checkpoint.iteration == -1:
             # -1 means training already finished.
             logger.error(
-                f"Trying to load continue from checkpoint, but the checkpoint"
-                f"indicates training already finished. Returning last"
-                f"checkpointed model instead.")
+                "Trying to load continue from checkpoint, but the checkpoint"
+                "indicates training already finished. Returning last"
+                "checkpointed model instead.")
             return kwargs["xgb_model"], {}, _training_state.additional_results
 
     # The callback_returns dict contains actor-rank indexed lists of

--- a/xgboost_ray/tests/test_matrix.py
+++ b/xgboost_ray/tests/test_matrix.py
@@ -286,6 +286,19 @@ class XGBoostRayDMatrixTest(unittest.TestCase):
                 print("MLDataset not available in current Ray version. "
                       "Skipping part of test.")
 
+    def testTooManyActorsDistributed(self):
+        """Test error when too many actors are passed"""
+        with self.assertRaises(RuntimeError):
+            dtrain = RayDMatrix(["foo.csv"], num_actors=4, distributed=True)
+            dtrain.assert_enough_shards_for_actors(4)
+
+    def testTooManyActorsCentral(self):
+        """Test error when too many actors are passed"""
+        data_df = pd.DataFrame(self.x, columns=["a", "b", "c", "d"])
+
+        with self.assertRaises(RuntimeError):
+            RayDMatrix(data_df, num_actors=34, distributed=False)
+
 
 if __name__ == "__main__":
     import pytest


### PR DESCRIPTION
Closes #12, concerns #81

Currently we don't check if we assign too many actors to too few data shards. This PR introduces a check that will raise an error if we assign too many workers to too few data sources, which would leave some actors without any data to train on.