### PR TITLE
Compatibility with xgboost 1.4 (remove feature names form numpy arrays)

### DIFF
--- a/xgboost_ray/data_sources/data_source.py
+++ b/xgboost_ray/data_sources/data_source.py
@@ -1,8 +1,9 @@
-from typing import Any, Optional, Sequence, Tuple, Dict
+from typing import Any, Optional, Sequence, Tuple, Dict, List
 
 from enum import Enum
 
 import pandas as pd
+import xgboost as xgb
 
 from ray.actor import ActorHandle
 
@@ -83,6 +84,19 @@ class DataSource:
             Pandas DataFrame.
         """
         raise NotImplementedError
+
+    @staticmethod
+    def update_feature_names(matrix: xgb.DMatrix,
+                             feature_names: Optional[List[str]]):
+        """Optionally update feature names before training/prediction
+
+        Args:
+            matrix (xgb.DMatrix): xgboost DMatrix object.
+            feature_names (List[str]): Feature names manually passed to the
+                ``RayDMatrix`` objet.
+
+        """
+        pass
 
     @staticmethod
     def convert_to_series(data: Any) -> pd.Series:

--- a/xgboost_ray/data_sources/data_source.py
+++ b/xgboost_ray/data_sources/data_source.py
@@ -93,7 +93,7 @@ class DataSource:
         Args:
             matrix (xgb.DMatrix): xgboost DMatrix object.
             feature_names (List[str]): Feature names manually passed to the
-                ``RayDMatrix`` objet.
+                ``RayDMatrix`` object.
 
         """
         pass

--- a/xgboost_ray/data_sources/numpy.py
+++ b/xgboost_ray/data_sources/numpy.py
@@ -1,7 +1,8 @@
-from typing import Any, Optional, Sequence
+from typing import Any, Optional, Sequence, List
 
 import numpy as np
 import pandas as pd
+import xgboost as xgb
 
 from xgboost_ray.data_sources.data_source import DataSource, RayFileType
 from xgboost_ray.data_sources.pandas import Pandas
@@ -14,6 +15,12 @@ class Numpy(DataSource):
     def is_data_type(data: Any,
                      filetype: Optional[RayFileType] = None) -> bool:
         return isinstance(data, np.ndarray)
+
+    @staticmethod
+    def update_feature_names(matrix: xgb.DMatrix,
+                             feature_names: Optional[List[str]]):
+        # Potentially unset feature names
+        matrix.feature_names = feature_names
 
     @staticmethod
     def load_data(data: np.ndarray,

--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -254,6 +254,8 @@ def _get_dmatrix(data: RayDMatrix, param: Dict) -> xgb.DMatrix:
 
         matrix = xgb.DMatrix(**param)
         matrix.set_info(label_lower_bound=ll, label_upper_bound=lu)
+
+    data.update_matrix_properties(matrix)
     return matrix
 
 
@@ -1306,6 +1308,7 @@ def train(
         evals_result.update(train_evals_result)
     if isinstance(additional_results, dict):
         additional_results.update(train_additional_results)
+
     return bst
 
 

--- a/xgboost_ray/matrix.py
+++ b/xgboost_ray/matrix.py
@@ -14,6 +14,7 @@ except ImportError:
 
 import numpy as np
 import pandas as pd
+import xgboost as xgb
 
 import os
 
@@ -173,6 +174,10 @@ class _RayDMatrixLoader:
 
     def get_data_source(self) -> Type[DataSource]:
         raise NotImplementedError
+
+    def update_matrix_properties(self, matrix: xgb.DMatrix):
+        data_source = self.get_data_source()
+        data_source.update_feature_names(matrix, self.feature_names)
 
     def assign_shards_to_actors(self, actors: Sequence[ActorHandle]) -> bool:
         """Assign data shards to actors.
@@ -719,6 +724,9 @@ class RayDMatrix:
             for name in list(self.refs[rank].keys()):
                 del self.refs[rank][name]
         self.loaded = False
+
+    def update_matrix_properties(self, matrix: xgb.DMatrix):
+        self.loader.update_matrix_properties(matrix)
 
     def __hash__(self):
         return self._uid


### PR DESCRIPTION
Converting numpy arrays to pandas dataframes for sharding implicitly adds coluimn names which are stored in the reuslting xgboost booster objects. However, calling `predict` on such boosters with numpy arrays leads to errors. Instead we should unset feature names for numpy arrays if they haven't been deliberately passed to `RayDMatrix`.