### PR TITLE
Use rabit ranks instead of xgboost-ray-ranks for checkpointing and result reporting

### DIFF
--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -410,12 +410,12 @@ class RayXGBoostActor:
 
         class _SaveInternalCheckpointCallback(TrainingCallback):
             def after_iteration(self, model, epoch, evals_log):
-                if this.rank == 0 and \
+                if xgb.rabit.get_rank() == 0 and \
                         epoch % this.checkpoint_frequency == 0:
                     put_queue(_Checkpoint(epoch, pickle.dumps(model)))
 
             def after_training(self, model):
-                if this.rank == 0:
+                if xgb.rabit.get_rank() == 0:
                     put_queue(_Checkpoint(-1, pickle.dumps(model)))
                 return model
 

--- a/xgboost_ray/session.py
+++ b/xgboost_ray/session.py
@@ -54,6 +54,11 @@ def get_actor_rank() -> int:
     return session.get_actor_rank()
 
 
+def get_rabit_rank() -> int:
+    import xgboost as xgb
+    return xgb.rabit.get_rank()
+
+
 def put_queue(*args, **kwargs):
     session = get_session()
     session.put_queue(*args, **kwargs)

--- a/xgboost_ray/tune.py
+++ b/xgboost_ray/tune.py
@@ -10,7 +10,7 @@ except ImportError:
 import logging
 
 from xgboost_ray.compat import TrainingCallback
-from xgboost_ray.session import put_queue, get_actor_rank
+from xgboost_ray.session import put_queue, get_rabit_rank
 from xgboost_ray.util import Unavailable
 
 try:
@@ -77,7 +77,7 @@ if TUNE_LEGACY and TUNE_INSTALLED:
             return report_dict
 
         def after_iteration(self, model, epoch: int, evals_log: Dict):
-            if get_actor_rank() == 0:
+            if get_rabit_rank() == 0:
                 report_dict = self._get_report_dict(evals_log)
                 put_queue(lambda: tune.report(**report_dict))
 
@@ -96,7 +96,7 @@ if TUNE_LEGACY and TUNE_INSTALLED:
                 model.save_model(os.path.join(checkpoint_dir, filename))
 
         def after_iteration(self, model, epoch: int, evals_log: Dict):
-            if get_actor_rank() == 0:
+            if get_rabit_rank() == 0:
                 put_queue(lambda: self._create_checkpoint(
                     model, epoch, self._filename, self._frequency))
 
@@ -115,7 +115,7 @@ if TUNE_LEGACY and TUNE_INSTALLED:
             self._report = self._report_callbacks_cls(metrics)
 
         def after_iteration(self, model, epoch: int, evals_log: Dict):
-            if get_actor_rank() == 0:
+            if get_rabit_rank() == 0:
                 self._checkpoint.after_iteration(model, epoch, evals_log)
                 self._report.after_iteration(model, epoch, evals_log)
 
@@ -123,13 +123,13 @@ elif TUNE_INSTALLED:
     # New style callbacks.
     class TuneReportCallback(OrigTuneReportCallback):
         def after_iteration(self, model, epoch: int, evals_log: Dict):
-            if get_actor_rank() == 0:
+            if get_rabit_rank() == 0:
                 report_dict = self._get_report_dict(evals_log)
                 put_queue(lambda: tune.report(**report_dict))
 
     class _TuneCheckpointCallback(_OrigTuneCheckpointCallback):
         def after_iteration(self, model, epoch: int, evals_log: Dict):
-            if get_actor_rank() == 0:
+            if get_rabit_rank() == 0:
                 put_queue(lambda: self._create_checkpoint(
                     model, epoch, self._filename, self._frequency))
 


### PR DESCRIPTION
Currently we're using the XGBoost-Ray generated actor ranks (that differ from those assigned by Rabit) to decide which actor should report checkpoints or Tune results back to the driver.

This is faulty in elastic training: If the rank 0 actor dies and the other actors continue training, no checkpoints or tune results will be reported back.

With this PR, we use the Rabit-provided ranks instead. Rabit always assigns ranks anew, starting with rank 0, so this guarantees we will always have an actor reporting results and checkpoints.