### PR TITLE
Only one remote actor should return its Booster

### DIFF
--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -924,12 +924,12 @@ def _train(params: Dict,
     ]
     training_futures = [
         actor.train.remote(
+            rabit_args,
+            i == 0,  # return_bst
+            params,
+            dtrain,
+            evals,
             *args,
-            rabit_args=rabit_args,
-            return_bst=i == 0,
-            params=params,
-            dtrain=dtrain,
-            evals=evals,
             **kwargs) for i, actor in enumerate(live_actors)
     ]
 

--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -924,12 +924,12 @@ def _train(params: Dict,
     ]
     training_futures = [
         actor.train.remote(
+            *args,
             rabit_args=rabit_args,
             return_bst=i == 0,
             params=params,
             dtrain=dtrain,
             evals=evals,
-            *args,
             **kwargs) for i, actor in enumerate(live_actors)
     ]
 

--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -923,8 +923,14 @@ def _train(params: Dict,
         actor for actor in _training_state.actors if actor is not None
     ]
     training_futures = [
-        actor.train.remote(rabit_args, i == 0, params, dtrain, evals, *args,
-                           **kwargs) for i, actor in enumerate(live_actors)
+        actor.train.remote(
+            rabit_args=rabit_args,
+            return_bst=i == 0,
+            params=params,
+            dtrain=dtrain,
+            evals=evals,
+            *args,
+            **kwargs) for i, actor in enumerate(live_actors)
     ]
 
     # Failure handling loop. Here we wait until all training tasks finished.


### PR DESCRIPTION
Currently each actor returns the trained Booster object.

This is inefficient:

1. All Booster objects are the same
2. Transferring large Boosters over slow networks can lead to much overhead
3. We call `ray.get()` three times on each of the training futures. Although results should be cached, this doesn't always seem to be the case

Instead, only the first live training actor should return its Booster object. 

Also, we want to minimize the number of calls to `ray.get()`.

This should fix an issue that came up training with 150 workers where each individual result fetch would take about 2 seconds to complete.

cc @mmui

