### PR TITLE
Raise from XGBoostError in remote worker

### DIFF
--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -8,9 +8,10 @@ import time
 import threading
 
 import numpy as np
+import pandas as pd
 
 import xgboost as xgb
-from xgboost.core import XGBoostError
+from xgboost.core import XGBoostError, EarlyStopException
 
 from xgboost_ray.callback import DistributedCallback, \
     DistributedCallbackContainer
@@ -510,6 +511,7 @@ class RayXGBoostActor:
         kwargs["callbacks"] = callbacks
 
         result_dict = {}
+        error_dict = {}
 
         # We run xgb.train in a thread to be able to react to the stop event.
         def _train():
@@ -538,8 +540,12 @@ class RayXGBoostActor:
                         "evals_result": evals_result,
                         "train_n": self._local_n[dtrain]
                     })
-            except XGBoostError:
-                # Silent fail, will be raised as RayXGBoostTrainingStopped
+            except EarlyStopException:
+                # Usually this should be caught by XGBoost core.
+                # Silent fail, will be raised as RayXGBoostTrainingStopped.
+                return
+            except XGBoostError as e:
+                error_dict.update({"exception": e})
                 return
 
         thread = threading.Thread(target=_train)
@@ -552,7 +558,8 @@ class RayXGBoostActor:
             time.sleep(0.1)
 
         if not result_dict:
-            raise RayXGBoostTrainingError("Training failed.")
+            raise_from = error_dict.get("exception", None)
+            raise RayXGBoostTrainingError("Training failed.") from raise_from
 
         thread.join()
         self._distributed_callbacks.after_train(self, result_dict)
@@ -571,7 +578,7 @@ class RayXGBoostActor:
             self.load_data(data)
         local_data = self._data[data]
 
-        predictions = model.predict(local_data, **kwargs)
+        predictions = pd.Series(model.predict(local_data, **kwargs))
         self._distributed_callbacks.after_predict(self, predictions)
         return predictions
 


### PR DESCRIPTION
Closes #97 

Example:

```
from sklearn.datasets import load_digits
from xgboost_ray import RayDMatrix, train, RayParams

train_x, train_y = load_digits(return_X_y=True)
train_set = RayDMatrix(train_x, train_y)

bst = train(
    {"objective": "multi:softmax", "num_class": 20, "eval_metric": ["logloss", "error"]},
    train_set,
    evals=[(train_set, "train")],
    ray_params=RayParams(num_actors=1)
)
```

Result:

```
2021-05-17 14:58:31,589	INFO services.py:1264 -- View the Ray dashboard at http://127.0.0.1:8265
2021-05-17 14:58:34,860	INFO main.py:849 -- [RayXGBoost] Created 1 new actors (1 total actors). Waiting until actors are ready for training.
2021-05-17 14:58:36,400	INFO main.py:894 -- [RayXGBoost] Starting XGBoost training.
(pid=87003) [14:58:36] task [xgboost.ray]:4834888208 got new rank 0
2021-05-17 14:58:36,572	INFO elastic.py:156 -- Actor status: 1 alive, 0 dead (1 total)
Traceback (most recent call last):
  File "/Users/kai/coding/xgboost_ray/xgboost_ray/main.py", line 975, in _train
    ray.get(ready)
  File "/Users/kai/coding/ray/python/ray/_private/client_mode_hook.py", line 62, in wrapper
    return func(*args, **kwargs)
  File "/Users/kai/coding/ray/python/ray/worker.py", line 1472, in get
    raise value.as_instanceof_cause()
ray.exceptions.RayTaskError(RayXGBoostTrainingError): ray::RayXGBoostActor.train() (pid=87003, ip=10.212.57.96)
  File "/Users/kai/.pyenv/versions/3.7.7/lib/python3.7/site-packages/xgboost/training.py", line 197, in train
    early_stopping_rounds=early_stopping_rounds)
  File "/Users/kai/.pyenv/versions/3.7.7/lib/python3.7/site-packages/xgboost/training.py", line 82, in _train_internal
    if callbacks.after_iteration(bst, i, dtrain, evals):
  File "/Users/kai/.pyenv/versions/3.7.7/lib/python3.7/site-packages/xgboost/callback.py", line 432, in after_iteration
    score = model.eval_set(evals, epoch, self.metric)
  File "/Users/kai/.pyenv/versions/3.7.7/lib/python3.7/site-packages/xgboost/core.py", line 1566, in eval_set
    ctypes.byref(msg)))
  File "/Users/kai/.pyenv/versions/3.7.7/lib/python3.7/site-packages/xgboost/core.py", line 210, in _check_call
    raise XGBoostError(py_str(_LIB.XGBGetLastError()))
xgboost.core.XGBoostError: [14:58:36] /Users/travis/build/dmlc/xgboost/src/metric/elementwise_metric.cu:366: Check failed: preds.Size() == info.labels_.Size() (35940 vs. 1797) : label and prediction size not match, hint: use merror or mlogloss for multi-class classification
Stack trace:
  [bt] (0) 1   libxgboost.dylib                    0x00000001c5778064 dmlc::LogMessageFatal::~LogMessageFatal() + 116
  [bt] (1) 2   libxgboost.dylib                    0x00000001c585310f xgboost::metric::EvalEWiseBase<xgboost::metric::EvalRowLogLoss>::Eval(xgboost::HostDeviceVector<float> const&, xgboost::MetaInfo const&, bool) + 319
  [bt] (2) 3   libxgboost.dylib                    0x00000001c582ab63 xgboost::LearnerImpl::EvalOneIter(int, std::__1::vector<std::__1::shared_ptr<xgboost::DMatrix>, std::__1::allocator<std::__1::shared_ptr<xgboost::DMatrix> > > const&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&) + 2355
  [bt] (3) 4   libxgboost.dylib                    0x00000001c576f4bc XGBoosterEvalOneIter + 572
  [bt] (4) 5   _ctypes.cpython-37m-darwin.so       0x0000000114069e57 ffi_call_unix64 + 79
  [bt] (5) 6   ???                                 0x000070000d157710 0x0 + 123145521821456



The above exception was the direct cause of the following exception:

ray::RayXGBoostActor.train() (pid=87003, ip=10.212.57.96)
  File "python/ray/_raylet.pyx", line 489, in ray._raylet.execute_task
  File "python/ray/_raylet.pyx", line 496, in ray._raylet.execute_task
  File "python/ray/_raylet.pyx", line 500, in ray._raylet.execute_task
  File "python/ray/_raylet.pyx", line 450, in ray._raylet.execute_task.function_executor
  File "/Users/kai/coding/ray/python/ray/_private/function_manager.py", line 566, in actor_method_executor
    return method(__ray_actor, *args, **kwargs)
  File "/Users/kai/coding/xgboost_ray/xgboost_ray/main.py", line 558, in train
    raise RayXGBoostTrainingError("Training failed.") from raise_from
xgboost_ray.main.RayXGBoostTrainingError: Training failed.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/kai/coding/xgboost_ray/xgboost_ray/main.py", line 1273, in train
    **kwargs)
  File "/Users/kai/coding/xgboost_ray/xgboost_ray/main.py", line 998, in _train
    raise RayActorError from exc
ray.exceptions.RayActorError: The actor died unexpectedly before finishing this task.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/kai/coding/sandbox/xgboost_swallow.py", line 11, in <module>
    ray_params=RayParams(num_actors=1)
  File "/Users/kai/coding/xgboost_ray/xgboost_ray/main.py", line 1337, in train
    ) from exc
RuntimeError: A Ray actor died during training and the maximum number of retries (0) is exhausted.
```