### PR TITLE
Fix issues with objective="multi:softprob"

### DIFF
--- a/xgboost_ray/callback.py
+++ b/xgboost_ray/callback.py
@@ -45,8 +45,8 @@ class DistributedCallback(ABC):
     def before_predict(self, actor: "RayXGBoostActor", *args, **kwargs):
         pass
 
-    def after_predict(self, actor: "RayXGBoostActor", predictions: pd.Series,
-                      *args, **kwargs):
+    def after_predict(self, actor: "RayXGBoostActor",
+                      predictions: pd.DataFrame, *args, **kwargs):
         pass
 
 
@@ -81,8 +81,8 @@ class DistributedCallbackContainer:
         for callback in self.callbacks:
             callback.before_predict(actor, *args, **kwargs)
 
-    def after_predict(self, actor: "RayXGBoostActor", predictions: pd.Series,
-                      *args, **kwargs):
+    def after_predict(self, actor: "RayXGBoostActor",
+                      predictions: pd.DataFrame, *args, **kwargs):
         for callback in self.callbacks:
             callback.after_predict(actor, predictions, *args, **kwargs)
 

--- a/xgboost_ray/callback.py
+++ b/xgboost_ray/callback.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import Dict, Sequence, TYPE_CHECKING, Any
+from typing import Dict, Sequence, TYPE_CHECKING, Any, Union
 
 import os
 import pandas as pd
@@ -46,7 +46,8 @@ class DistributedCallback(ABC):
         pass
 
     def after_predict(self, actor: "RayXGBoostActor",
-                      predictions: pd.DataFrame, *args, **kwargs):
+                      predictions: Union[pd.Series, pd.DataFrame], *args,
+                      **kwargs):
         pass
 
 
@@ -82,7 +83,8 @@ class DistributedCallbackContainer:
             callback.before_predict(actor, *args, **kwargs)
 
     def after_predict(self, actor: "RayXGBoostActor",
-                      predictions: pd.DataFrame, *args, **kwargs):
+                      predictions: Union[pd.Series, pd.DataFrame], *args,
+                      **kwargs):
         for callback in self.callbacks:
             callback.after_predict(actor, predictions, *args, **kwargs)
 

--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -578,7 +578,7 @@ class RayXGBoostActor:
             self.load_data(data)
         local_data = self._data[data]
 
-        predictions = pd.Series(model.predict(local_data, **kwargs))
+        predictions = pd.DataFrame(model.predict(local_data, **kwargs))
         self._distributed_callbacks.after_predict(self, predictions)
         return predictions
 

--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -579,8 +579,11 @@ class RayXGBoostActor:
         local_data = self._data[data]
 
         predictions = model.predict(local_data, **kwargs)
-        self._distributed_callbacks.after_predict(self,
-                                                  pd.DataFrame(predictions))
+        if predictions.ndim == 1:
+            callback_predictions = pd.Series(predictions)
+        else:
+            callback_predictions = pd.DataFrame(predictions)
+        self._distributed_callbacks.after_predict(self, callback_predictions)
         return predictions
 
 

--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -578,8 +578,9 @@ class RayXGBoostActor:
             self.load_data(data)
         local_data = self._data[data]
 
-        predictions = pd.DataFrame(model.predict(local_data, **kwargs))
-        self._distributed_callbacks.after_predict(self, predictions)
+        predictions = model.predict(local_data, **kwargs)
+        self._distributed_callbacks.after_predict(self,
+                                                  pd.DataFrame(predictions))
         return predictions
 
 

--- a/xgboost_ray/tests/test_end_to_end.py
+++ b/xgboost_ray/tests/test_end_to_end.py
@@ -192,7 +192,9 @@ class XGBoostRayEndToEndTest(unittest.TestCase):
         self.assertSequenceEqual(list(self.y), list(pred_y))
 
     def testTrainPredictSoftprob(self):
-        """Train with evaluation and predict on softprob objective"""
+        """Train with evaluation and predict on softprob objective
+        (which returns predictions in a 2d array)
+        """
         self.testTrainPredict(init=True, softprob=True)
 
     def testTrainPredictRemote(self):

--- a/xgboost_ray/tests/test_end_to_end.py
+++ b/xgboost_ray/tests/test_end_to_end.py
@@ -148,16 +148,25 @@ class XGBoostRayEndToEndTest(unittest.TestCase):
         pred_y = bst.predict(x_mat)
         self.assertSequenceEqual(list(self.y), list(pred_y))
 
-    def testTrainPredict(self, init=True, remote=None, **ray_param_dict):
+    def testTrainPredict(self,
+                         init=True,
+                         remote=None,
+                         softprob=False,
+                         **ray_param_dict):
         """Train with evaluation and predict"""
         if init:
             ray.init(num_cpus=2, num_gpus=0)
 
         dtrain = RayDMatrix(self.x, self.y)
 
+        params = self.params
+        if softprob:
+            params = params.copy()
+            params["objective"] = "multi:softprob"
+
         evals_result = {}
         bst = train(
-            self.params,
+            params,
             dtrain,
             num_boost_round=38,
             ray_params=RayParams(num_actors=2, **ray_param_dict),
@@ -175,7 +184,16 @@ class XGBoostRayEndToEndTest(unittest.TestCase):
             x_mat,
             ray_params=RayParams(num_actors=2, **ray_param_dict),
             _remote=remote)
+
+        if softprob:
+            self.assertEqual(pred_y.shape[1], len(np.unique(self.y)))
+            pred_y = np.argmax(pred_y, axis=1)
+
         self.assertSequenceEqual(list(self.y), list(pred_y))
+
+    def testTrainPredictSoftprob(self):
+        """Train with evaluation and predict on softprob objective"""
+        self.testTrainPredict(init=True, softprob=True)
 
     def testTrainPredictRemote(self):
         """Train with evaluation and predict in a remote call"""


### PR DESCRIPTION
`objective="multi:softprob"` returns a 2d array instead of a 1d array during prediction. This caused issues with `predict` as it expected a 1d array. This PR fixes this, as well as the handling of BATCH sharding mode during prediction (though I think it still fails on training).

The only change to the public API would be that the callback receives a pandas DataFrame instead of a Series, but I don't think it will cause many issues.

A test was added.