### PR TITLE
Fail CI if tests do not pass

### DIFF
--- a/run_ci_examples.sh
+++ b/run_ci_examples.sh
@@ -1,3 +1,5 @@
+set -e
+
 TUNE=1
 
 for i in "$@"

--- a/run_ci_tests.sh
+++ b/run_ci_tests.sh
@@ -18,19 +18,25 @@ pushd xgboost_ray/tests || exit 1
 echo "============="
 echo "Running tests"
 echo "============="
-python -m pytest -vv -s --log-cli-level=DEBUG --durations=0 -x test_colocation.py
-python -m pytest -v --durations=0 -x test_matrix.py
-python -m pytest -v --durations=0 -x test_data_source.py
-python -m pytest -v --durations=0 -x test_xgboost_api.py
-python -m pytest -v --durations=0 -x test_fault_tolerance.py
-python -m pytest -v --durations=0 -x test_end_to_end.py
-python -m pytest -v --durations=0 -x test_sklearn.py
+END_STATUS=0
+if ! python -m pytest -vv -s --log-cli-level=DEBUG --durations=0 -x "test_colocation.py" ; then END_STATUS=1; fi
+if ! python -m pytest -v --durations=0 -x "test_matrix.py" ; then END_STATUS=1; fi
+if ! python -m pytest -v --durations=0 -x "test_data_source.py" ; then END_STATUS=1; fi
+if ! python -m pytest -v --durations=0 -x "test_xgboost_api.py" ; then END_STATUS=1; fi
+if ! python -m pytest -v --durations=0 -x "test_fault_tolerance.py" ; then END_STATUS=1; fi
+if ! python -m pytest -v --durations=0 -x "test_end_to_end.py" ; then END_STATUS=1; fi
+if ! python -m pytest -v --durations=0 -x "test_sklearn.py" ; then END_STATUS=1; fi
 
 if [ "$TUNE" = "1" ]; then
-  python -m pytest -v --durations=0 -x test_tune.py
+  if ! python -m pytest -v --durations=0 -x "test_tune.py" ; then END_STATUS=1; fi
 else
   echo "skipping tune tests"
 fi
 
-echo "running smoke test on benchmark_cpu_gpu.py" && python release/benchmark_cpu_gpu.py 2 10 20 --smoke-test
+echo "running smoke test on benchmark_cpu_gpu.py" && if python release/benchmark_cpu_gpu.py 2 10 20 --smoke-test; then END_STATUS=1; fi
 popd || exit 1
+
+if [ "$END_STATUS" = "1" ]; then
+  echo "At least one test has failed, exiting with code 1"
+fi
+exit "$END_STATUS"

--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -132,10 +132,7 @@ class _RabitTracker(RabitTracker):
         multiprocessing.set_start_method("fork", force=True)
 
         def run():
-            try:
-                self.accept_slaves(nslave)
-            except AssertionError as exc:
-                logger.exception(exc)
+            self.accept_slaves(nslave)
 
         self.thread = multiprocessing.Process(target=run, args=())
         self.thread.start()

--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -132,7 +132,10 @@ class _RabitTracker(RabitTracker):
         multiprocessing.set_start_method("fork", force=True)
 
         def run():
-            self.accept_slaves(nslave)
+            try:
+                self.accept_slaves(nslave)
+            except AssertionError as exc:
+                logger.exception(exc)
 
         self.thread = multiprocessing.Process(target=run, args=())
         self.thread.start()

--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -448,6 +448,8 @@ class RayXGBoostActor:
                     if this._stop_event.is_set() or \
                             this._get_stop_event() is not initial_stop_event:
                         # Returning True stops training
+                        if LEGACY_CALLBACK:
+                            raise EarlyStopException
                         return True
                 except RayActorError:
                     return True

--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -447,11 +447,13 @@ class RayXGBoostActor:
                 try:
                     if this._stop_event.is_set() or \
                             this._get_stop_event() is not initial_stop_event:
-                        # Returning True stops training
                         if LEGACY_CALLBACK:
-                            raise EarlyStopException
+                            raise EarlyStopException(epoch)
+                        # Returning True stops training
                         return True
                 except RayActorError:
+                    if LEGACY_CALLBACK:
+                        raise EarlyStopException(epoch)
                     return True
 
         return _StopCallback()

--- a/xgboost_ray/tests/fault_tolerance.py
+++ b/xgboost_ray/tests/fault_tolerance.py
@@ -6,9 +6,8 @@ from typing import Dict, Tuple, Set
 import ray
 from ray.actor import ActorHandle
 
-from xgboost.callback import TrainingCallback
-
 from xgboost_ray.callback import DistributedCallback
+from xgboost_ray.compat import TrainingCallback
 from xgboost_ray.session import get_actor_rank
 
 

--- a/xgboost_ray/tests/fault_tolerance.py
+++ b/xgboost_ray/tests/fault_tolerance.py
@@ -81,6 +81,7 @@ class DelayedLoadingCallback(DistributedCallback):
         print(f"Rank {actor.rank} - after load")
         while ray.get(self.ft_manager.should_sleep.remote(actor.rank)):
             time.sleep(self.sleep_time)
+        print(f"Rank {actor.rank} - returning now")
 
 
 class DieCallback(TrainingCallback):

--- a/xgboost_ray/tests/fault_tolerance.py
+++ b/xgboost_ray/tests/fault_tolerance.py
@@ -47,10 +47,13 @@ class FaultToleranceManager:
 
     def should_die(self, rank: int):
         """Returns True if the actor should terminate the training job now."""
-        if rank in self.scheduled_kill[self.global_boost_round]:
-            self.scheduled_kill[self.global_boost_round].remove(rank)
-            return True
-        return False
+        die = False
+        for round in range(self.global_boost_round + 1):
+            # Loop through all rounds until now to deal with race conditions
+            if rank in self.scheduled_kill[round]:
+                self.scheduled_kill[round].remove(rank)
+                die = True
+        return die
 
     def should_sleep(self, rank: int):
         """Returns True if the actor should not finish data loading, yet."""

--- a/xgboost_ray/tests/test_colocation.py
+++ b/xgboost_ray/tests/test_colocation.py
@@ -110,7 +110,7 @@ class TestColocation(unittest.TestCase):
                 finally:
                     assert len(_training_state.actors) == 2
                     if not any(a is None for a in _training_state.actors):
-                        actor_infos = ray.actors()
+                        actor_infos = ray.state.actors()
                         actor_nodes = []
                         for a in _training_state.actors:
                             actor_info = actor_infos.get(a._actor_id.hex())
@@ -151,7 +151,7 @@ class TestColocation(unittest.TestCase):
                 finally:
                     assert len(_training_state.actors) == num_actors
                     if not any(a is None for a in _training_state.actors):
-                        actor_infos = ray.actors()
+                        actor_infos = ray.state.actors()
                         actor_nodes = []
                         for a in _training_state.actors:
                             actor_info = actor_infos.get(a._actor_id.hex())

--- a/xgboost_ray/tests/test_data_source.py
+++ b/xgboost_ray/tests/test_data_source.py
@@ -15,6 +15,7 @@ from xgboost_ray.data_sources.modin import MODIN_INSTALLED
 from xgboost_ray.data_sources.dask import DASK_INSTALLED
 
 
+@unittest.skip("Abstract test")
 class _DistributedDataSourceTest(unittest.TestCase):
     def setUp(self):
         repeat = 8  # Repeat data a couple of times for stability

--- a/xgboost_ray/tests/test_fault_tolerance.py
+++ b/xgboost_ray/tests/test_fault_tolerance.py
@@ -573,7 +573,7 @@ class XGBoostRayFaultToleranceTest(unittest.TestCase):
         self.assertIn(15, global_steps)
         self.assertNotIn(17, global_steps)
         self.assertNotIn(67, global_steps)
-        self.assertIn(70, global_steps)
+        self.assertIn(75, global_steps)
 
 
 if __name__ == "__main__":

--- a/xgboost_ray/tests/test_fault_tolerance.py
+++ b/xgboost_ray/tests/test_fault_tolerance.py
@@ -16,7 +16,7 @@ from xgboost_ray.main import RayXGBoostActorAvailable
 from xgboost_ray.tests.fault_tolerance import FaultToleranceManager, \
     DelayedLoadingCallback, DieCallback
 from xgboost_ray.tests.utils import flatten_obj, _checkpoint_callback, \
-    _fail_callback, tree_obj, _kill_callback, _sleep_callback, get_num_trees
+    _fail_callback, tree_obj, _kill_callback, get_num_trees
 
 
 class _FakeTask(MagicMock):
@@ -153,6 +153,16 @@ class XGBoostRayFaultToleranceTest(unittest.TestCase):
         """This should continue after one actor died and restart it."""
         logging.getLogger().setLevel(10)
 
+        ft_manager = FaultToleranceManager.remote()
+
+        ft_manager.schedule_kill.remote(rank=0, boost_round=6)
+        ft_manager.delay_return.remote(
+            rank=1, start_boost_round=12, end_boost_round=21)
+
+        delay_callback = DelayedLoadingCallback(
+            ft_manager, reload_data=True, sleep_time=0.1)
+        die_callback = DieCallback(ft_manager, training_delay=0.25)
+
         additional_results = {}
         keep_actors = {}
 
@@ -165,17 +175,14 @@ class XGBoostRayFaultToleranceTest(unittest.TestCase):
             bst = train(
                 self.params,
                 RayDMatrix(self.x, self.y),
-                callbacks=[
-                    _kill_callback(self.die_lock_file, fail_iteration=6),
-                    _sleep_callback(sleep_iteration=7, sleep_seconds=15),
-                    _sleep_callback(sleep_iteration=9, sleep_seconds=5)
-                ],
+                callbacks=[die_callback],
                 num_boost_round=20,
                 ray_params=RayParams(
                     max_actor_restarts=1,
                     num_actors=2,
                     elastic_training=True,
-                    max_failed_actors=1),
+                    max_failed_actors=1,
+                    distributed_callbacks=[delay_callback]),
                 additional_results=additional_results)
 
         self.assertEqual(20, get_num_trees(bst))

--- a/xgboost_ray/tests/test_sklearn.py
+++ b/xgboost_ray/tests/test_sklearn.py
@@ -478,7 +478,8 @@ class XGBoostRaySklearnTest(unittest.TestCase):
         tr_d, te_d, tr_l, te_l = train_test_split(
             iris.data, iris.target, train_size=120, test_size=0.2)
 
-        classifier = RayXGBClassifier(booster="gbtree", n_estimators=10)
+        classifier = RayXGBClassifier(
+            booster="gbtree", n_estimators=10, random_state=self.seed)
         classifier.fit(tr_d, tr_l)
 
         preds = classifier.predict(te_d)
@@ -497,7 +498,8 @@ class XGBoostRaySklearnTest(unittest.TestCase):
         tr_d, te_d, tr_l, te_l = train_test_split(
             iris.data, iris.target, train_size=120)
 
-        classifier = RayXGBClassifier(booster="gblinear", n_estimators=100)
+        classifier = RayXGBClassifier(
+            booster="gblinear", n_estimators=100, random_state=self.seed)
         classifier.fit(tr_d, tr_l)
 
         preds = classifier.predict(te_d)


### PR DESCRIPTION
This PR makes the CI scripts exit with correct status if at least one test fails. Previously, no matter what the test results were, the CI always passed (aside from linting). This may uncover some bad tests/errors that were not noticed before.

The `run_ci_tests.sh` script was made so that all tests will run instead of exiting CI as soon as a pytest invocation fails in order to simplify debugging. Same could be done for examples but I don't think it's worth it.