### PR TITLE
Increase test timeout limits

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,7 @@ jobs:
 
   test_linux_ray_master:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 40
     strategy:
       matrix:
         python-version: [3.6.9, 3.7, 3.8]
@@ -68,7 +68,7 @@ jobs:
 
   test_linux_ray_release:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 40
     strategy:
       matrix:
         python-version: [3.6.9, 3.7, 3.8]
@@ -101,7 +101,7 @@ jobs:
     # Test compatibility when some optional libraries are missing
     # Test runs on latest ray release
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 40
     strategy:
       matrix:
         python-version: [3.6.9, 3.7, 3.8]
@@ -138,7 +138,7 @@ jobs:
   test_linux_cutting_edge:
     # Tests on cutting edge, i.e. latest Ray master, latest XGBoost master
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 40
     strategy:
       matrix:
         python-version: [3.6.9, 3.7, 3.8]
@@ -194,7 +194,7 @@ jobs:
   test_linux_xgboost_legacy:
     # Tests on XGBoost 0.90 and latest Ray release
     runs-on: ubuntu-latest
-    timeout-minutes: 28
+    timeout-minutes: 40
     strategy:
       matrix:
         python-version: [3.6.9]


### PR DESCRIPTION
Currently tests are failing due to timeouts.

For now, let's increase test times. In the future, let's make sure to address #112 soon.
