### PR TITLE
Fix `num_threads` param, check for `n_jobs` param

### DIFF
--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -494,7 +494,8 @@ class RayXGBoostActor:
 
         if "nthread" not in local_params and "n_jobs" not in local_params:
             if num_threads > 0:
-                local_params["num_threads"] = num_threads
+                local_params["nthread"] = num_threads
+                local_params["n_jobs"] = num_threads
             else:
                 local_params["nthread"] = sum(
                     num

--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -829,14 +829,20 @@ def _train(params: Dict,
     # Un-schedule possible scheduled restarts
     _training_state.restart_training_at = None
 
-    if "nthread" in params:
-        if params["nthread"] > cpus_per_actor:
+    if "nthread" in params or "n_jobs" in params:
+        if "nthread" in params and params["nthread"] > cpus_per_actor:
+            raise ValueError(
+                "Specified number of threads greater than number of CPUs. "
+                "\nFIX THIS by passing a lower value for the `nthread` "
+                "parameter or a higher number for `cpus_per_actor`.")
+        if "n_jobs" in params and params["n_jobs"] > cpus_per_actor:
             raise ValueError(
                 "Specified number of threads greater than number of CPUs. "
                 "\nFIX THIS by passing a lower value for the `nthread` "
                 "parameter or a higher number for `cpus_per_actor`.")
     else:
         params["nthread"] = cpus_per_actor
+        params["n_jobs"] = cpus_per_actor
 
     # This is a callback that handles actor failures.
     # We identify the rank of the failed actor, add this to a set of


### PR DESCRIPTION
According to [xgboost source code](https://github.com/dmlc/xgboost/blob/master/include/xgboost/generic_parameters.h), `num_threads` is not a valid parameter, and `n_jobs` is an alias of `nthread`. This PR fixes the usage of the former and adds a missing check for latter.