### PR TITLE
Separate out `_RayXGBoostActor`

### DIFF
--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -351,8 +351,7 @@ def _validate_ray_params(ray_params: Union[None, RayParams, dict]) \
     return ray_params
 
 
-@ray.remote
-class RayXGBoostActor:
+class _RayXGBoostActor:
     """Remote Ray XGBoost actor class.
 
     This remote actor handles local training and prediction of one data
@@ -603,6 +602,11 @@ class RayXGBoostActor:
             callback_predictions = pd.DataFrame(predictions)
         self._distributed_callbacks.after_predict(self, callback_predictions)
         return predictions
+
+
+@ray.remote
+class RayXGBoostActor(_RayXGBoostActor):
+    pass
 
 
 class _PrepareActorTask(MultiActorTask):

--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -351,7 +351,7 @@ def _validate_ray_params(ray_params: Union[None, RayParams, dict]) \
     return ray_params
 
 
-class _RayXGBoostActor:
+class RayXGBoostActor:
     """Remote Ray XGBoost actor class.
 
     This remote actor handles local training and prediction of one data
@@ -605,7 +605,7 @@ class _RayXGBoostActor:
 
 
 @ray.remote
-class RayXGBoostActor(_RayXGBoostActor):
+class _RemoteRayXGBoostActor(RayXGBoostActor):
     pass
 
 
@@ -656,7 +656,7 @@ def _create_actor(
         checkpoint_frequency: int = 5,
         distributed_callbacks: Optional[Sequence[DistributedCallback]] = None
 ) -> ActorHandle:
-    return RayXGBoostActor.options(
+    return _RemoteRayXGBoostActor.options(
         num_cpus=num_cpus_per_actor,
         num_gpus=num_gpus_per_actor,
         resources=resources_per_actor,

--- a/xgboost_ray/tests/test_data_source.py
+++ b/xgboost_ray/tests/test_data_source.py
@@ -9,7 +9,7 @@ import ray
 from ray import ObjectRef
 
 from xgboost_ray.data_sources import Modin, Dask
-from xgboost_ray.main import RayXGBoostActor
+from xgboost_ray.main import _RemoteRayXGBoostActor
 
 from xgboost_ray.data_sources.modin import MODIN_INSTALLED
 from xgboost_ray.data_sources.dask import DASK_INSTALLED
@@ -280,7 +280,7 @@ class ModinDataSourceTest(_DistributedDataSourceTest):
 
         # Create ray actors
         actors = [
-            RayXGBoostActor.options(resources={
+            _RemoteRayXGBoostActor.options(resources={
                 f"node:{nip}": 0.1
             }).remote(rank=rank, num_actors=len(actor_nodes))
             for rank, nip in enumerate(actor_node_ips)
@@ -415,7 +415,7 @@ class DaskDataSourceTest(_DistributedDataSourceTest):
 
         # Create ray actors
         actors = [
-            RayXGBoostActor.options(resources={
+            _RemoteRayXGBoostActor.options(resources={
                 f"node:{nip}": 0.1
             }).remote(rank=rank, num_actors=len(actor_nodes))
             for rank, nip in enumerate(actor_node_ips)

--- a/xgboost_ray/tests/test_fault_tolerance.py
+++ b/xgboost_ray/tests/test_fault_tolerance.py
@@ -418,7 +418,7 @@ class XGBoostRayFaultToleranceTest(unittest.TestCase):
 
     @patch("xgboost_ray.main._PrepareActorTask", _FakeTask)
     @patch("xgboost_ray.elastic._PrepareActorTask", _FakeTask)
-    @patch("xgboost_ray.main.RayXGBoostActor", MagicMock)
+    @patch("xgboost_ray.main._RemoteRayXGBoostActor", MagicMock)
     @patch("xgboost_ray.main.ELASTIC_RESTART_GRACE_PERIOD_S", 30)
     @patch("xgboost_ray.elastic.ELASTIC_RESTART_GRACE_PERIOD_S", 30)
     def testMaybeScheduleNewActors(self):


### PR DESCRIPTION
Separate out `_RayXGBoostActor` class to enable inheritance in projects using xgboost-ray as a dependency