### PR TITLE
Support modin 0.10.0

### DIFF
--- a/xgboost_ray/data_sources/modin.py
+++ b/xgboost_ray/data_sources/modin.py
@@ -14,7 +14,8 @@ from xgboost_ray.data_sources.object_store import ObjectStore
 
 try:
     import modin  # noqa: F401
-    MODIN_INSTALLED = modin.__version__ >= "0.9.0"
+    from distutils.version import LooseVersion
+    MODIN_INSTALLED = LooseVersion(modin.__version__) >= LooseVersion("0.9.0")
 except (ImportError, AttributeError):
     MODIN_INSTALLED = False
 

--- a/xgboost_ray/matrix.py
+++ b/xgboost_ray/matrix.py
@@ -283,8 +283,8 @@ class _CentralRayDMatrixLoader(_RayDMatrixLoader):
                 "file, path, consider passing the `filetype` argument to "
                 "specify the type of the source. Use the `RayFileType` "
                 "enum for that. If using Modin, Dask, or Petastorm, "
-                "make sure the library is installed.".format(type(
-                    self.data), self.filetype))
+                "make sure the library is installed.".format(
+                    type(self.data), self.filetype))
 
         if self.label is not None and not isinstance(self.label, str) and \
                 not type(self.data) != type(self.label):  # noqa: E721:
@@ -361,7 +361,6 @@ class _DistributedRayDMatrixLoader(_RayDMatrixLoader):
     """Load each shard individually."""
 
     def get_data_source(self) -> Type[DataSource]:
-        import pdb; pdb.set_trace()
         if self.data_source:
             return self.data_source
 

--- a/xgboost_ray/matrix.py
+++ b/xgboost_ray/matrix.py
@@ -282,7 +282,9 @@ class _CentralRayDMatrixLoader(_RayDMatrixLoader):
                 "np.ndarray, and CSV/Parquet file paths. If you specify a "
                 "file, path, consider passing the `filetype` argument to "
                 "specify the type of the source. Use the `RayFileType` "
-                "enum for that.".format(type(self.data), self.filetype))
+                "enum for that. If using Modin, Dask, or Petastorm, "
+                "make sure the library is installed.".format(type(
+                    self.data), self.filetype))
 
         if self.label is not None and not isinstance(self.label, str) and \
                 not type(self.data) != type(self.label):  # noqa: E721:
@@ -359,6 +361,7 @@ class _DistributedRayDMatrixLoader(_RayDMatrixLoader):
     """Load each shard individually."""
 
     def get_data_source(self) -> Type[DataSource]:
+        import pdb; pdb.set_trace()
         if self.data_source:
             return self.data_source
 
@@ -419,7 +422,9 @@ class _DistributedRayDMatrixLoader(_RayDMatrixLoader):
                 f"with FileType: {self.filetype} for a distributed dataset."
                 "\nFIX THIS by passing a supported data type. Supported "
                 "data types for distributed datasets are a list of "
-                "CSV or Parquet sources as well as Ray MLDatasets.")
+                "CSV or Parquet sources as well as Ray MLDatasets. If using "
+                "Modin, Dask, or Petastorm, make sure the library is "
+                "installed.")
 
         self.data_source = data_source
         self._cached_n = data_source.get_n(self.data)

--- a/xgboost_ray/tests/test_client.py
+++ b/xgboost_ray/tests/test_client.py
@@ -39,6 +39,7 @@ def test_simple_dask(start_client_server_5_cpus):
     from xgboost_ray.examples.simple_dask import main
     main(cpus_per_actor=1, num_actors=4)
 
+
 def test_simple_modin(start_client_server_5_cpus):
     assert ray.util.client.ray.is_connected()
     from xgboost_ray.examples.simple_modin import main

--- a/xgboost_ray/tests/test_client.py
+++ b/xgboost_ray/tests/test_client.py
@@ -15,7 +15,7 @@ def start_client_server_4_cpus():
 
 @pytest.fixture
 def start_client_server_5_cpus():
-    ray.init(num_cpus=4)
+    ray.init(num_cpus=5)
     with ray_start_client_server() as client:
         yield client
 
@@ -37,6 +37,11 @@ def test_simple_tune(start_client_server_4_cpus):
 def test_simple_dask(start_client_server_5_cpus):
     assert ray.util.client.ray.is_connected()
     from xgboost_ray.examples.simple_dask import main
+    main(cpus_per_actor=1, num_actors=4)
+
+def test_simple_modin(start_client_server_5_cpus):
+    assert ray.util.client.ray.is_connected()
+    from xgboost_ray.examples.simple_modin import main
     main(cpus_per_actor=1, num_actors=4)
 
 


### PR DESCRIPTION
Currently we are using string comparison to check for valid modin versions `MODIN_INSTALLED = modin.__version__ >= "0.9.0"`. Modin recently released 0.10.0 last week which fails this check. Thus, if modin 0.10 is installed, xgboost-ray thinks that modin is not installed. This means that the modin CI tests are currently being skipped, and also causing xgboost-ray to not recognize modin as a valid data source (https://github.com/ray-project/xgboost_ray/issues/116). Instead, we should do a more robust version check. Also, this PR tests the simple modin example with Ray Client now that 0.10 is released.

Closes https://github.com/ray-project/xgboost_ray/issues/116