### PR TITLE
[rfc] Change default value of placement group from None to "default"

### DIFF
--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -1,5 +1,6 @@
 from typing import Tuple, Dict, Any, List, Optional, Callable, Union, Sequence
 from dataclasses import dataclass, field
+from distutils.version import LooseVersion
 
 import multiprocessing
 import os
@@ -32,7 +33,7 @@ try:
     from xgboost_ray.util import Event, Queue, MultiActorTask, \
         force_on_current_node
 
-    if ray.__version__ > "1.4.0":
+    if LooseVersion(ray.__version__) > LooseVersion("1.4.0"):
         # https://github.com/ray-project/ray/pull/16437
         DEFAULT_PG = "default"
     else:

--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -647,7 +647,7 @@ def _create_actor(
         num_cpus_per_actor: int,
         num_gpus_per_actor: int,
         resources_per_actor: Optional[Dict] = None,
-        placement_group: Optional[PlacementGroup] = None,
+        placement_group: Optional[PlacementGroup] = "default",
         queue: Optional[Queue] = None,
         checkpoint_frequency: int = 5,
         distributed_callbacks: Optional[Sequence[DistributedCallback]] = None
@@ -1270,7 +1270,7 @@ def train(
                                      ray_params.resources_per_actor,
                                      ray_params.num_actors, placement_strategy)
     else:
-        pg = None
+        pg = "default"
 
     start_actor_ranks = set(range(ray_params.num_actors))  # Start these
 

--- a/xgboost_ray/tests/test_data_source.py
+++ b/xgboost_ray/tests/test_data_source.py
@@ -15,7 +15,7 @@ from xgboost_ray.data_sources.modin import MODIN_INSTALLED
 from xgboost_ray.data_sources.dask import DASK_INSTALLED
 
 
-class _DistributedDataSourceTest(unittest.TestCase):
+class _DistributedDataSourceTest:
     def setUp(self):
         repeat = 8  # Repeat data a couple of times for stability
         self.x = np.repeat(range(8), 16).reshape((32, 4))
@@ -181,7 +181,7 @@ class _DistributedDataSourceTest(unittest.TestCase):
 @unittest.skipIf(
     not MODIN_INSTALLED,
     reason="Modin is not installed in a supported version.")
-class ModinDataSourceTest(_DistributedDataSourceTest):
+class ModinDataSourceTest(_DistributedDataSourceTest, unittest.TestCase):
     """This test suite validates core RayDMatrix functionality."""
 
     def _testAssignPartitions(self, part_nodes, actor_nodes,
@@ -301,7 +301,7 @@ class ModinDataSourceTest(_DistributedDataSourceTest):
 
 @unittest.skipIf(
     not DASK_INSTALLED, reason="Dask is not installed in a supported version.")
-class DaskDataSourceTest(_DistributedDataSourceTest):
+class DaskDataSourceTest(_DistributedDataSourceTest, unittest.TestCase):
     """This test suite validates core RayDMatrix functionality."""
 
     def _testAssignPartitions(self, part_nodes, actor_nodes,

--- a/xgboost_ray/tests/test_data_source.py
+++ b/xgboost_ray/tests/test_data_source.py
@@ -15,7 +15,6 @@ from xgboost_ray.data_sources.modin import MODIN_INSTALLED
 from xgboost_ray.data_sources.dask import DASK_INSTALLED
 
 
-@unittest.skip("Abstract test")
 class _DistributedDataSourceTest(unittest.TestCase):
     def setUp(self):
         repeat = 8  # Repeat data a couple of times for stability


### PR DESCRIPTION
Please read https://github.com/ray-project/ray/issues/16507 for the bug and context.
Here is a summary:
- After #[16437](https://github.com/ray-project/ray/pull/16437) the Actor placement behavior [has changed for ](https://github.com/ray-project/ray/pull/16437/files#diff-f67ab59de16332a2ea8df0fb7032ea69a0912c3bb52538649b4ed0c9fc21d9d2R636)`placement_group = None` versus `placement_group = "default"`; 
- Also in #[16437](https://github.com/ray-project/ray/pull/16437), by default the `placement_group` is set to `"default"` instead of `None` [when creating Ray Actors](https://github.com/ray-project/ray/pull/16437/files#diff-f67ab59de16332a2ea8df0fb7032ea69a0912c3bb52538649b4ed0c9fc21d9d2R500).
- However in when tune_small.py test runs,  RayXGBoostActor's`placement_group` was to `None`, which leads to allocation failure;
- So [this line sets ](https://github.com/ray-project/xgboost_ray/blob/6b9fb5e2cf68ec0e0039702bcd0bd8f362931279/xgboost_ray/main.py#L1241) the RayXGBoostActor with None placement group; verified changing it to "default" fixes the issue.

This is an attempt to fix it in xgboost_ray by substituting the default placement group from `None` to `default`. However this might change the behavior if xgboost_ray running with old ray version. Let me know how do we want to deal with this api behavior change. cc @ericl  @krfricke 