### PR TITLE
Add `ray_dmatrix_params` to sklearn API

### DIFF
--- a/xgboost_ray/sklearn.py
+++ b/xgboost_ray/sklearn.py
@@ -184,6 +184,8 @@ _RAY_PARAMS_DOC = """ray_params (Union[None, RayParams, Dict]): Parameters to co
             with own ``num_actors`` parameter.
         _remote (bool): Whether to run the driver process in a remote
             function. This is enabled by default in Ray client mode.
+        ray_dmatrix_params (Optional[Dict]): Dict of parameters (such as sharding mode)
+            passed to the internal RayDMatrix initialization.
 
 """
 

--- a/xgboost_ray/sklearn.py
+++ b/xgboost_ray/sklearn.py
@@ -184,8 +184,9 @@ _RAY_PARAMS_DOC = """ray_params (Union[None, RayParams, Dict]): Parameters to co
             with own ``num_actors`` parameter.
         _remote (bool): Whether to run the driver process in a remote
             function. This is enabled by default in Ray client mode.
-        ray_dmatrix_params (Optional[Dict]): Dict of parameters (such as sharding mode)
-            passed to the internal RayDMatrix initialization.
+        ray_dmatrix_params (Optional[Dict]): Dict of parameters
+            (such as sharding mode) passed to the internal RayDMatrix
+            initialization.
 
 """
 


### PR DESCRIPTION
Adds a way to pass keyword params to `RayDMatrix` created internally in sklearn API estimators.