### PR TITLE
Pin tensorboardX for CI

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -9,3 +9,6 @@ ray[tune]
 scikit-learn
 modin
 dask
+
+#workaround for now
+tensorboardX==2.2


### PR DESCRIPTION
Temporary fix to allow for CI to pass. Newest tensorboardX release (2.3) added Pillow and Torch as dependencies without specifying them in requirements. Looks to be unintentional but it breaks CI in the meantime. Once tensorboardX releases a fix it can be removed from the test dependencies here