### PR TITLE
fix placement group timeout behavior

### DIFF
--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -756,7 +756,7 @@ def _create_placement_group(cpus_per_actor, gpus_per_actor,
     # Wait for placement group to get created.
     logger.debug("Waiting for placement group to start.")
     ready, _ = ray.wait([pg.ready()], timeout=PLACEMENT_GROUP_TIMEOUT_S)
-    if ready is not None:
+    if ready:
         logger.debug("Placement group has started.")
     else:
         raise TimeoutError("Placement group creation timed out. Make sure "

--- a/xgboost_ray/tests/test_colocation.py
+++ b/xgboost_ray/tests/test_colocation.py
@@ -176,12 +176,13 @@ class TestColocation(unittest.TestCase):
                 num_samples=1,
             )
 
+    @patch("xgboost_ray.main.PLACEMENT_GROUP_TIMEOUT_S", 5)
     def test_timeout(self):
         """Checks that an error occurs when placement group setup times out."""
         with self.ray_start_cluster() as cluster:
             ray.init(address=cluster.address)
 
-            with pytest.raises(TimeoutError):
+            with self.assertRaises(TimeoutError):
                 train(
                     self.params,
                     RayDMatrix(self.x, self.y),

--- a/xgboost_ray/tests/test_colocation.py
+++ b/xgboost_ray/tests/test_colocation.py
@@ -176,6 +176,21 @@ class TestColocation(unittest.TestCase):
                 num_samples=1,
             )
 
+    def test_timeout(self):
+        """Checks that an error occurs when placement group setup times out."""
+        with self.ray_start_cluster() as cluster:
+            ray.init(address=cluster.address)
+
+            with pytest.raises(TimeoutError):
+                train(
+                    self.params,
+                    RayDMatrix(self.x, self.y),
+                    num_boost_round=2,
+                    ray_params=RayParams(
+                        max_actor_restarts=1,
+                        num_actors=2,
+                        resources_per_actor={"invalid": 1}))
+
 
 if __name__ == "__main__":
     import pytest  # noqa: F811


### PR DESCRIPTION
When placement group setup times out, we are expected to raise a `TimeoutError` and fail immediately. When `ray.wait` times out, the first object returned will be an _empty list_, not `None`. This PR fixes the logic so that a timeout will properly route to a `TimeoutError`.

**Testing Done:** Added a new `test_timeout` test in `test_colocation.py` that tries to request an invalid resource. Without this change, the code will hang in `_train` as it waits for the actors to be prepared.