### PR TITLE
Update Ray Datasets import

### DIFF
--- a/xgboost_ray/data_sources/ray_dataset.py
+++ b/xgboost_ray/data_sources/ray_dataset.py
@@ -13,7 +13,7 @@ from xgboost_ray.data_sources.data_source import DataSource, RayFileType
 from xgboost_ray.data_sources.object_store import ObjectStore
 
 try:
-    import ray.experimental.data.dataset  # noqa: F401
+    import ray.data.dataset  # noqa: F401
     RAY_DATASET_AVAILABLE = True
 except (ImportError, AttributeError):
     RAY_DATASET_AVAILABLE = False
@@ -41,11 +41,11 @@ class RayDataset(DataSource):
         if not RAY_DATASET_AVAILABLE:
             return False
 
-        return isinstance(data, ray.experimental.data.dataset.Dataset)
+        return isinstance(data, ray.data.dataset.Dataset)
 
     @staticmethod
     def load_data(
-            data: Any,  # ray.experimental.data.dataset.Dataset
+            data: Any,  # ray.data.dataset.Dataset
             ignore: Optional[Sequence[str]] = None,
             indices: Optional[Union[Sequence[int], Sequence[
                 ObjectRef]]] = None,
@@ -70,7 +70,7 @@ class RayDataset(DataSource):
 
     @staticmethod
     def get_actor_shards(
-            data: Any,  # ray.experimental.data.dataset.Dataset
+            data: Any,  # ray.data.dataset.Dataset
             actors: Sequence[ActorHandle]) -> \
             Tuple[Any, Optional[Dict[int, Any]]]:
         _assert_ray_data_available()

--- a/xgboost_ray/examples/simple_ray_dataset.py
+++ b/xgboost_ray/examples/simple_ray_dataset.py
@@ -25,7 +25,7 @@ def main(cpus_per_actor, num_actors):
     partitions = [ray.put(part) for part in np.split(data, 4)]
 
     # Generate Ray dataset
-    ray_ds = ray.experimental.data.from_pandas(partitions)
+    ray_ds = ray.data.from_pandas(partitions)
 
     train_set = RayDMatrix(ray_ds, "label")
 

--- a/xgboost_ray/matrix.py
+++ b/xgboost_ray/matrix.py
@@ -29,7 +29,7 @@ except ImportError:
     MLDataset = Unavailable
 
 try:
-    from ray.experimental.data.dataset import Dataset as RayDataset
+    from ray.data.dataset import Dataset as RayDataset
 except (ImportError, ModuleNotFoundError):
 
     class RayDataset:

--- a/xgboost_ray/tests/test_data_source.py
+++ b/xgboost_ray/tests/test_data_source.py
@@ -495,7 +495,7 @@ class RayDatasetSourceTest(_DistributedDataSourceTest, unittest.TestCase):
             mock_nodes.side_effect = node_map
             mock_ranks.side_effect = actor_ranks
 
-            data = ray.experimental.data.from_pandas(list(part_to_node.keys()))
+            data = ray.data.from_pandas(list(part_to_node.keys()))
 
             _, actor_to_parts = RayDataset.get_actor_shards(
                 data=data, actors=[])
@@ -528,7 +528,7 @@ class RayDatasetSourceTest(_DistributedDataSourceTest, unittest.TestCase):
         ])
 
         # Create Ray dataset from distributed partitions
-        ray_ds = ray.experimental.data.from_pandas(node_dfs)
+        ray_ds = ray.data.from_pandas(node_dfs)
 
         df_objs = ray_ds.to_pandas()
         ray.wait(df_objs)


### PR DESCRIPTION
Ray Datasets path has been changed from `ray.experimental.data` to `ray.data` in the nightlies, breaking support here. This PR updates the imports in `xgboost_ray`.