### PR TITLE
Validate `train` kwargs

### DIFF
--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -9,6 +9,7 @@ import time
 import threading
 import warnings
 import re
+import inspect
 
 import numpy as np
 import pandas as pd
@@ -795,6 +796,16 @@ def _create_communication_processes(added_tune_callback: bool = False):
     return queue, stop_event
 
 
+def _validate_kwargs_for_func(kwargs: Dict[str, Any], func: Callable, func_name: str):
+    """Raise exception if kwargs are not valid for a given function."""
+    valid_keys = inspect.getfullargspec(func)[0]
+    invalid_kwargs = [k for k in kwargs if not k in valid_keys]
+    if invalid_kwargs:
+        raise TypeError(
+            f"Got invalid keyword arguments to be passed to `{func_name}`. "
+            f"Invalid keys: {invalid_kwargs}"
+        )
+
 @dataclass
 class _TrainingState:
     actors: List[Optional[ActorHandle]]
@@ -1167,6 +1178,8 @@ def train(
         return bst
 
     _maybe_print_legacy_warning()
+    # may raise TypeError
+    _validate_kwargs_for_func(kwargs, xgb.train, "xgb.train()")
 
     start_time = time.time()
 

--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -796,10 +796,11 @@ def _create_communication_processes(added_tune_callback: bool = False):
     return queue, stop_event
 
 
-def _validate_kwargs_for_func(kwargs: Dict[str, Any], func: Callable, func_name: str):
+def _validate_kwargs_for_func(kwargs: Dict[str, Any], func: Callable,
+                              func_name: str):
     """Raise exception if kwargs are not valid for a given function."""
     valid_keys = inspect.getfullargspec(func)[0]
-    invalid_kwargs = [k for k in kwargs if not k in valid_keys]
+    invalid_kwargs = [k for k in kwargs if k not in valid_keys]
     if invalid_kwargs:
         raise TypeError(
             f"Got invalid keyword arguments to be passed to `{func_name}`. "

--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -803,8 +803,8 @@ def _validate_kwargs_for_func(kwargs: Dict[str, Any], func: Callable, func_name:
     if invalid_kwargs:
         raise TypeError(
             f"Got invalid keyword arguments to be passed to `{func_name}`. "
-            f"Invalid keys: {invalid_kwargs}"
-        )
+            f"Invalid keys: {invalid_kwargs}")
+
 
 @dataclass
 class _TrainingState:

--- a/xgboost_ray/tests/test_end_to_end.py
+++ b/xgboost_ray/tests/test_end_to_end.py
@@ -323,6 +323,24 @@ class XGBoostRayEndToEndTest(unittest.TestCase):
             self.assertIn("label and prediction size not match",
                           str(exc.__cause__.__cause__))
 
+    def testKwargsValidation(self):
+        x = np.random.uniform(0, 1, size=(100, 4))
+        y = np.random.randint(0, 1, size=100)
+
+        train_set = RayDMatrix(x, y)
+
+        with self.assertRaisesRegex(TypeError, "totally_invalid_kwarg"):
+            train(
+                {
+                    "objective": "multi:softmax",
+                    "num_class": 2,
+                    "eval_metric": ["logloss", "error"]
+                },
+                train_set,
+                evals=[(train_set, "train")],
+                ray_params=RayParams(num_actors=1, max_actor_restarts=0),
+                totally_invalid_kwarg="")
+
 
 if __name__ == "__main__":
     import pytest


### PR DESCRIPTION
Ensures that the kwargs passed to `train` are actually valid for `xgb.train()`.