### PR TITLE
Remove usage of deprecated ray.services.get_node_ip_address

### DIFF
--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -24,10 +24,9 @@ from xgboost_ray.compat import TrainingCallback, RabitTracker, LEGACY_CALLBACK
 try:
     import ray
     from ray import logger
-    from ray.services import get_node_ip_address
     from ray.exceptions import RayActorError, RayTaskError
     from ray.actor import ActorHandle
-    from ray.util import placement_group
+    from ray.util import get_node_ip_address, placement_group
     from ray.util.placement_group import PlacementGroup, \
         remove_placement_group, get_current_placement_group
 

--- a/xgboost_ray/tests/release/tune_placement.py
+++ b/xgboost_ray/tests/release/tune_placement.py
@@ -30,9 +30,9 @@ from xgboost_ray.compat import TrainingCallback
 import ray
 
 from ray import tune
-from ray.services import get_node_ip_address
 from ray.tune.session import get_trial_id
 from ray.tune.integration.docker import DockerSyncer
+from ray.util import get_node_ip_address
 
 from benchmark_cpu_gpu import train_ray
 from xgboost_ray import RayParams


### PR DESCRIPTION
Deprecated from Ray 1.4, will be removed in upstream: https://github.com/ray-project/ray/pull/18475