### PR TITLE
Fix xgboost-ray[default] git install

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ pip install "xgboost_ray[default]"
 If you'd like to install the latest master, use this command instead:
 
 ```bash
-pip install "git+https://github.com/ray-project/xgboost_ray.git#xgboost_ray[default]"
+pip install "git+https://github.com/ray-project/xgboost_ray.git#egg=xgboost_ray[default]"
 ```
 
 Omitting `[default]` will cause `xgboost` to not be installed as a dependency.

--- a/xgboost_ray/tests/release/run_e2e_gpu.sh
+++ b/xgboost_ray/tests/release/run_e2e_gpu.sh
@@ -6,7 +6,7 @@ fi
 NOW=$(date +%s)
 export SESSION_NAME="xgboost_ray_ci_gpu_${NOW}"
 export NUM_WORKERS=3
-export XGBOOST_RAY_PACKAGE="git+https://github.com/ray-project/xgboost_ray.git@${GITHUB_SHA:-master}#xgboost_ray"
+export XGBOOST_RAY_PACKAGE="git+https://github.com/ray-project/xgboost_ray.git@${GITHUB_SHA:-master}#egg=xgboost_ray[default]"
 export NO_TMUX=1
 
 ./start_gpu_cluster.sh

--- a/xgboost_ray/tests/release/tune_cluster.yaml
+++ b/xgboost_ray/tests/release/tune_cluster.yaml
@@ -35,8 +35,8 @@ file_mounts_sync_continuously: true
 initialization_commands: []
 setup_commands:
     - pip install -U ray
-    - pip install -U git+https://github.com/ray-project/xgboost_ray#xgboost-ray[default]
-    - pip install -U git+https://github.com/amogkam/xgboost_ray.git@colocation#xgboost-ray[default]
+    - pip install -U git+https://github.com/ray-project/xgboost_ray#egg=xgboost-ray[default]
+    - pip install -U git+https://github.com/amogkam/xgboost_ray.git@colocation#egg=xgboost-ray[default]
     - mkdir -p /data
     - rm -rf /data/tune_test.parquet || true
     - python /release_tests/create_test_data.py /data/tune_test.parquet --seed 1234 --num-rows 2000 --num-cols 4 --num-partitions 40 --num-classes 2


### PR DESCRIPTION
The `egg=` suffix is necessary for correct installation of `[default]` extras