### PR TITLE
Preserve ordering of columns on conversion to RayDMatrix

### DIFF
--- a/xgboost_ray/matrix.py
+++ b/xgboost_ray/matrix.py
@@ -2,7 +2,7 @@ import glob
 import uuid
 from enum import Enum
 from typing import Union, Optional, Tuple, Iterable, List, Dict, Sequence, \
-    Callable, Type, TYPE_CHECKING
+    Callable, Type, TYPE_CHECKING, Set
 
 from ray.actor import ActorHandle
 
@@ -223,30 +223,30 @@ class _RayDMatrixLoader:
         `label_upper_bound`
 
         """
-        exclude_cols: List[str] = []  # Exclude these columns from `x`
+        exclude_cols: Set[str] = set()  # Exclude these columns from `x`
 
         label, exclude = data_source.get_column(local_data, self.label)
         if exclude:
-            exclude_cols.append(exclude)
+            exclude_cols.add(exclude)
 
         weight, exclude = data_source.get_column(local_data, self.weight)
         if exclude:
-            exclude_cols.append(exclude)
+            exclude_cols.add(exclude)
 
         base_margin, exclude = data_source.get_column(local_data,
                                                       self.base_margin)
         if exclude:
-            exclude_cols.append(exclude)
+            exclude_cols.add(exclude)
 
         label_lower_bound, exclude = data_source.get_column(
             local_data, self.label_lower_bound)
         if exclude:
-            exclude_cols.append(exclude)
+            exclude_cols.add(exclude)
 
         label_upper_bound, exclude = data_source.get_column(
             local_data, self.label_upper_bound)
         if exclude:
-            exclude_cols.append(exclude)
+            exclude_cols.add(exclude)
 
         x = local_data
         if exclude_cols:

--- a/xgboost_ray/matrix.py
+++ b/xgboost_ray/matrix.py
@@ -250,7 +250,7 @@ class _RayDMatrixLoader:
 
         x = local_data
         if exclude_cols:
-            x = x[x.columns.difference(exclude_cols)]
+            x = x[[col for col in x.columns if col not in exclude_cols]]
 
         return x, label, weight, base_margin, label_lower_bound, \
             label_upper_bound

--- a/xgboost_ray/tests/test_matrix.py
+++ b/xgboost_ray/tests/test_matrix.py
@@ -43,6 +43,16 @@ class XGBoostRayDMatrixTest(unittest.TestCase):
         data = RayDMatrix(self.x, self.y)
         self.assertTrue(ray.get(same.remote(data, data)))
 
+    def testColumnOrdering(self):
+        """when excluding cols, the remaining col order should be preserved."""
+
+        cols = [str(i) for i in range(50)]
+        df = pd.DataFrame(np.random.randn(1, len(cols)), columns=cols)
+        matrix = RayDMatrix(df, label=cols[-1], num_actors=1)
+        data = matrix.get_data(0)["data"]
+
+        assert data.columns.tolist() == cols[:-1]
+
     def _testMatrixCreation(self, in_x, in_y, **kwargs):
         if "sharding" not in kwargs:
             kwargs["sharding"] = RayShardingMode.BATCH

--- a/xgboost_ray/tests/test_matrix.py
+++ b/xgboost_ray/tests/test_matrix.py
@@ -44,7 +44,7 @@ class XGBoostRayDMatrixTest(unittest.TestCase):
         self.assertTrue(ray.get(same.remote(data, data)))
 
     def testColumnOrdering(self):
-        """when excluding cols, the remaining col order should be preserved."""
+        """When excluding cols, the remaining col order should be preserved."""
 
         cols = [str(i) for i in range(50)]
         df = pd.DataFrame(np.random.randn(1, len(cols)), columns=cols)


### PR DESCRIPTION
Conversion of a pandas dataframe to a RayDMatrix did not conserve the ordering of columns because this line would actually do a set difference: https://github.com/ray-project/xgboost_ray/blob/88c3188741650ac7c6e2383315b637c4462f65e7/xgboost_ray/matrix.py#L253

Instead we should conserve the order of the columns in the original dataframe.

Issue: https://discuss.ray.io/t/raydmatrix-reordering-dataframe-columns/3981