### PR TITLE
➕  Re-add pyarrow dependency to `install_requires`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,6 @@ setup(
     "distributed computing framework Ray.",
     url="https://github.com/ray-project/xgboost_ray",
     install_requires=[
-        "ray>=1.6", "numpy>=1.16,<1.20", "pandas", "wrapt>=1.12.1",
+        "ray>=1.6", "numpy>=1.16,<1.20", "pandas", "pyarrow", "wrapt>=1.12.1",
         "xgboost>=0.90"
     ])

--- a/setup.py
+++ b/setup.py
@@ -13,4 +13,3 @@ setup(
         "ray>=1.6", "numpy>=1.16,<1.20", "pandas", "wrapt>=1.12.1",
         "xgboost>=0.90"
     ])
-# pyarrow<5.0.0 pinned until petastorm is updated


### PR DESCRIPTION
# TL;DR

Fixes `ModuleNotFoundError: No module named 'pyarrow'` errors due to pyarrow  (accidentally?) being removed in #171.

