### PR TITLE
Pin min `xgboost` version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,5 @@ setup(
     url="https://github.com/ray-project/xgboost_ray",
     install_requires=[
         "ray>=1.6", "numpy>=1.16", "pandas", "wrapt>=1.12.1",
-        "xgboost>=0.90"
+        "xgboost>=1.4.0"
     ])


### PR DESCRIPTION
#189 added `qid` support, but `qid` arg in `DMatrix` was only added in `xgboost` version 1.4.0 (https://github.com/dmlc/xgboost/releases/tag/v1.4.0).

Currently `xgboost-ray` master does not work for older `xgboost` versions, so this PR updates the minimum required xgboost version needed to run this library.