### PR TITLE
[docs] update environment variable names in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,7 +512,7 @@ to implement placement strategies for better fault tolerance.
 By default, a SPREAD strategy is used for training, which attempts to spread all of the training workers
 across the nodes in a cluster on a best-effort basis. This improves fault tolerance since it minimizes the 
 number of worker failures when a node goes down, but comes at a cost of increased inter-node communication
-To disable this strategy, set the `USE_SPREAD_STRATEGY` environment variable to 0. If disabled, no
+To disable this strategy, set the `RXGB_USE_SPREAD_STRATEGY` environment variable to 0. If disabled, no
 particular placement strategy will be used.
 
 Note that this strategy is used only when `elastic_training` is not used. If `elastic_training` is set to `True`,
@@ -524,7 +524,7 @@ goes down, it will be less likely to impact multiple trials.
 
 When placement strategies are used, XGBoost-Ray will wait for 100 seconds for the required resources
 to become available, and will fail if the required resources cannot be reserved and the cluster cannot autoscale
-to increase the number of resources. You can change the `PLACEMENT_GROUP_TIMEOUT_S` environment variable to modify 
+to increase the number of resources. You can change the `RXGB_PLACEMENT_GROUP_TIMEOUT_S` environment variable to modify 
 how long this timeout should be. 
 
 More examples


### PR DESCRIPTION
When reading environment variables, `xgboost_ray` expects them to be [prefixed](https://github.com/ray-project/xgboost_ray/blob/a43eb4a919dc751b1db0b859b7ff09f06b1a2925/xgboost_ray/main.py#L75-L120) with `RXGB_`. This updates the README to use the correct names.

