### PR TITLE
Mitigate finishing too quickly

### DIFF
--- a/xgboost_ray/tests/test_tune.py
+++ b/xgboost_ray/tests/test_tune.py
@@ -67,11 +67,13 @@ class XGBoostRayTuneTest(unittest.TestCase):
     def testNumIters(self):
         """Test that the number of reported tune results is correct"""
         ray_params = RayParams(cpus_per_actor=1, num_actors=2)
+        params = self.params.copy()
+        params["num_boost_round"] = tune.gridsearch([1, 3])
         analysis = tune.run(
             self.train_func(ray_params),
             config=self.params,
             resources_per_trial=ray_params.get_tune_resources(),
-            num_samples=2)
+            num_samples=1)
 
         self.assertSequenceEqual(
             list(analysis.results_df["training_iteration"]),

--- a/xgboost_ray/tests/test_tune.py
+++ b/xgboost_ray/tests/test_tune.py
@@ -68,7 +68,7 @@ class XGBoostRayTuneTest(unittest.TestCase):
         """Test that the number of reported tune results is correct"""
         ray_params = RayParams(cpus_per_actor=1, num_actors=2)
         params = self.params.copy()
-        params["num_boost_round"] = tune.gridsearch([1, 3])
+        params["num_boost_round"] = tune.grid_search([1, 3])
         analysis = tune.run(
             self.train_func(ray_params),
             config=self.params,


### PR DESCRIPTION
Same as in https://github.com/ray-project/lightgbm_ray/pull/29

This doesn't seem to occur with XGBoost, but the same logic is introduced for consistency. `test_tune` has been similarly deflaked. 