### PR TITLE
Fail quickly on Windows

### DIFF
--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -1,4 +1,4 @@
-import sys
+import platform
 from typing import Tuple, Dict, Any, List, Optional, Callable, Union, Sequence
 from dataclasses import dataclass, field
 from distutils.version import LooseVersion

--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -1,3 +1,4 @@
+import sys
 from typing import Tuple, Dict, Any, List, Optional, Callable, Union, Sequence
 from dataclasses import dataclass, field
 from distutils.version import LooseVersion
@@ -195,10 +196,11 @@ class _RabitTracker(RabitTracker, _RabitTrackerCompatMixin):
         # In python 3.8, spawn is used as default process creation on macOS.
         # But spawn doesn't work because `run` is not pickleable.
         # For now we force the start method to use fork.
-        multiprocessing.set_start_method("fork", force=True)
+        multiprocessing.set_start_method("spawn", force=True)
 
         def run():
-            self.accept_workers(nworker)
+            self
+            # self.accept_workers(nworker)
 
         self.thread = multiprocessing.Process(target=run, args=())
         self.thread.start()
@@ -1229,6 +1231,9 @@ def train(
     Returns: An ``xgboost.Booster`` object.
     """
     os.environ.setdefault("RAY_IGNORE_UNHANDLED_ERRORS", "1")
+
+    if sys.platform.startswith("win"):
+        raise RuntimeError("xgboost-ray training is not supported on Windows.")
 
     if xgb is None:
         raise ImportError(

--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -1233,7 +1233,8 @@ def train(
     os.environ.setdefault("RAY_IGNORE_UNHANDLED_ERRORS", "1")
 
     if sys.platform.startswith("win"):
-        raise RuntimeError("xgboost-ray training is not supported on Windows.")
+        raise RuntimeError("xgboost-ray training is currently does not support "
+                           "Windows.")
 
     if xgb is None:
         raise ImportError(

--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -1231,7 +1231,7 @@ def train(
     """
     os.environ.setdefault("RAY_IGNORE_UNHANDLED_ERRORS", "1")
 
-    if sys.platform.startswith("win"):
+    if platform.system() == "Windows":
         raise RuntimeError("xgboost-ray training currently does not support "
                            "Windows.")
 

--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -199,8 +199,7 @@ class _RabitTracker(RabitTracker, _RabitTrackerCompatMixin):
         multiprocessing.set_start_method("fork", force=True)
 
         def run():
-            self
-            # self.accept_workers(nworker)
+            self.accept_workers(nworker)
 
         self.thread = multiprocessing.Process(target=run, args=())
         self.thread.start()

--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -196,7 +196,7 @@ class _RabitTracker(RabitTracker, _RabitTrackerCompatMixin):
         # In python 3.8, spawn is used as default process creation on macOS.
         # But spawn doesn't work because `run` is not pickleable.
         # For now we force the start method to use fork.
-        multiprocessing.set_start_method("spawn", force=True)
+        multiprocessing.set_start_method("fork", force=True)
 
         def run():
             self
@@ -1233,7 +1233,7 @@ def train(
     os.environ.setdefault("RAY_IGNORE_UNHANDLED_ERRORS", "1")
 
     if sys.platform.startswith("win"):
-        raise RuntimeError("xgboost-ray training is currently does not support "
+        raise RuntimeError("xgboost-ray training currently does not support "
                            "Windows.")
 
     if xgb is None:


### PR DESCRIPTION
`xgboost-ray` training currently does not work on Windows. This is because we use multiprocessing in the Rabit Tracker, but the run method is not serializable, so we have to use `fork` method instead of `spawn`. (see #42). 

However, Python multiprocessing does not support `fork` method on Windows.

This PR immediately raises an error if Windows OS is identified with a better error message.

See #208  