### PR TITLE
Remove code for legacy Ray versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,5 @@ setup(
     "distributed computing framework Ray.",
     url="https://github.com/ray-project/xgboost_ray",
     install_requires=[
-        "ray>=1.6", "numpy>=1.16", "pandas", "wrapt>=1.12.1",
-        "xgboost>=0.90"
+        "ray>=1.10", "numpy>=1.16", "pandas", "wrapt>=1.12.1", "xgboost>=0.90"
     ])

--- a/xgboost_ray/tests/test_colocation.py
+++ b/xgboost_ray/tests/test_colocation.py
@@ -8,9 +8,10 @@ import pytest
 import numpy as np
 
 import ray
+from ray.util.queue import _QueueActor
 from xgboost_ray import train, RayDMatrix, RayParams
 from xgboost_ray.main import _train
-from xgboost_ray.util import _EventActor, _QueueActor
+from xgboost_ray.util import _EventActor
 
 
 class _MockQueueActor(_QueueActor):
@@ -57,7 +58,7 @@ class TestColocation(unittest.TestCase):
             shutil.rmtree(self.tmpdir)
         ray.shutdown()
 
-    @patch("xgboost_ray.util._QueueActor", _MockQueueActor)
+    @patch("ray.util.queue._QueueActor", _MockQueueActor)
     @patch("xgboost_ray.util._EventActor", _MockEventActor)
     def test_communication_colocation(self):
         """Checks that Queue and Event actors are colocated with the driver."""

--- a/xgboost_ray/util.py
+++ b/xgboost_ray/util.py
@@ -4,7 +4,6 @@ import asyncio
 
 import ray
 from ray.util.annotations import DeveloperAPI
-from ray.util.queue import Queue as RayQueue, Empty, Full
 
 
 @DeveloperAPI
@@ -48,78 +47,6 @@ class Event:
         if self.actor:
             ray.kill(self.actor)
         self.actor = None
-
-
-# Remove after Ray 1.2 release.
-if getattr(RayQueue, "shutdown", None) is not None:
-    from ray.util.queue import _QueueActor
-else:
-    # Have to copy the class here so that we can subclass this for mocking.
-    # If we have the @ray.remote decorator, then we can't subclass it.
-    class _QueueActor:
-        def __init__(self, maxsize):
-            self.maxsize = maxsize
-            self.queue = asyncio.Queue(self.maxsize)
-
-        def qsize(self):
-            return self.queue.qsize()
-
-        def empty(self):
-            return self.queue.empty()
-
-        def full(self):
-            return self.queue.full()
-
-        async def put(self, item, timeout=None):
-            try:
-                await asyncio.wait_for(self.queue.put(item), timeout)
-            except asyncio.TimeoutError:
-                raise Full
-
-        async def get(self, timeout=None):
-            try:
-                return await asyncio.wait_for(self.queue.get(), timeout)
-            except asyncio.TimeoutError:
-                raise Empty
-
-        def put_nowait(self, item):
-            self.queue.put_nowait(item)
-
-        def put_nowait_batch(self, items):
-            # If maxsize is 0, queue is unbounded, so no need to check size.
-            if self.maxsize > 0 and len(items) + self.qsize() > self.maxsize:
-                raise Full(f"Cannot add {len(items)} items to queue of size "
-                           f"{self.qsize()} and maxsize {self.maxsize}.")
-            for item in items:
-                self.queue.put_nowait(item)
-
-        def get_nowait(self):
-            return self.queue.get_nowait()
-
-        def get_nowait_batch(self, num_items):
-            if num_items > self.qsize():
-                raise Empty(f"Cannot get {num_items} items from queue of size "
-                            f"{self.qsize()}.")
-            return [self.queue.get_nowait() for _ in range(num_items)]
-
-
-# Remove after Ray 1.2 release.
-@DeveloperAPI
-class Queue(RayQueue):
-    def __init__(self, maxsize: int = 0,
-                 actor_options: Optional[Dict] = None) -> None:
-        actor_options = actor_options or {}
-        self.maxsize = maxsize
-        self.actor = ray.remote(_QueueActor).options(**actor_options).remote(
-            self.maxsize)
-
-    def shutdown(self):
-        if getattr(RayQueue, "shutdown", None) is not None:
-            super(Queue, self).shutdown()
-        else:
-            if self.actor:
-                ray.kill(self.actor)
-            self.actor = None
 
 
 @DeveloperAPI


### PR DESCRIPTION
There are several places where we still have code paths for legacy Ray versions. With the next release we can require newer Ray versions to be used.