### PR TITLE
Reduce verbosity for ray events

### DIFF
--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -366,6 +366,8 @@ class RayParams:
             Defaults to 0 (no retries). Set to -1 for unlimited retries.
         checkpoint_frequency (int): How often to save checkpoints. Defaults
             to ``5`` (every 5th iteration).
+        verbose (bool): Whether to output Ray-specific info messages
+            during training/prediction.
     """
     # Actor scheduling
     num_actors: int = 0

--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -382,7 +382,7 @@ class RayParams:
     # Distributed callbacks
     distributed_callbacks: Optional[List[DistributedCallback]] = None
 
-    verbose: Optional[bool] = False
+    verbose: bool = False
 
     def get_tune_resources(self):
         """Return the resources to use for xgboost_ray training with Tune."""


### PR DESCRIPTION
Adds a verbose flag to RayParams to toggle events. Defaults to False, but open to discuss.

The main thing is that when using AIR/Tune, this logging becomes quite verbose.