### PR TITLE
Switch to use packaging.Version from distutils LooseVersion

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,6 +2,7 @@ flake8==3.7.7
 flake8-comprehensions
 flake8-quotes==2.0.0
 yapf==0.23.0
+packaging
 petastorm
 pytest
 pyarrow

--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,6 @@ setup(
     "distributed computing framework Ray.",
     url="https://github.com/ray-project/xgboost_ray",
     install_requires=[
-        "ray>=1.10", "numpy>=1.16", "pandas", "wrapt>=1.12.1", "xgboost>=0.90"
+        "ray>=1.10", "numpy>=1.16", "pandas", "wrapt>=1.12.1", "xgboost>=0.90",
+        'packaging'
     ])

--- a/xgboost_ray/data_sources/modin.py
+++ b/xgboost_ray/data_sources/modin.py
@@ -15,8 +15,8 @@ from xgboost_ray.data_sources.object_store import ObjectStore
 try:
     import modin  # noqa: F401
     from modin.config.envvars import Engine
-    from distutils.version import LooseVersion
-    MODIN_INSTALLED = LooseVersion(modin.__version__) >= LooseVersion("0.9.0")
+    from packaging.version import Version
+    MODIN_INSTALLED = Version(modin.__version__) >= Version("0.9.0")
 
     # Check if importing the Ray engine leads to errors
     Engine().get()

--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -1,7 +1,7 @@
 import platform
 from typing import Tuple, Dict, Any, List, Optional, Callable, Union, Sequence
 from dataclasses import dataclass, field
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import functools
 import multiprocessing
@@ -128,8 +128,8 @@ LEGACY_WARNING = (
     f"fully tested and supported for XGBoost >= 1.4. Please consider "
     f"upgrading your XGBoost version (`pip install -U xgboost`).")
 
-# XGBoost LooseVersion for comparisions
-XGBOOST_LOOSE_VERSION = LooseVersion(xgboost_version)
+# XGBoost Version for comparisions
+XGBOOST_VERSION = Version(xgboost_version)
 
 
 class RayXGBoostTrainingError(RuntimeError):
@@ -260,7 +260,7 @@ class _RabitContext:
 
 def _ray_get_actor_cpus():
     # Get through resource IDs
-    if LooseVersion(ray.__version__) < LooseVersion("2.0.0"):
+    if Version(ray.__version__) < Version("2.0.0"):
         # Remove after 2.2?
         resource_ids = ray.worker.get_resource_ids()
         if "CPU" in resource_ids:

--- a/xgboost_ray/sklearn.py
+++ b/xgboost_ray/sklearn.py
@@ -25,7 +25,7 @@ Requires xgboost>=0.90"""
 # https://github.com/dmlc/xgboost/blob/c6a0bdbb5a68232cd59ea556c981c633cc0646ca/LICENSE
 
 from typing import Callable, Tuple, Dict, Optional, Union, Any, List
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import numpy as np
 
@@ -35,7 +35,7 @@ import inspect
 
 from ray.util.annotations import PublicAPI, DeveloperAPI
 
-from xgboost_ray.main import (RayParams, train, predict, XGBOOST_LOOSE_VERSION,
+from xgboost_ray.main import (RayParams, train, predict, XGBOOST_VERSION,
                               LEGACY_WARNING)
 from xgboost_ray.matrix import RayDMatrix
 
@@ -236,7 +236,7 @@ def _xgboost_version_warn(f):
 
     @functools.wraps(f)
     def inner_f(*args, **kwargs):
-        if XGBOOST_LOOSE_VERSION < LooseVersion("1.4.0"):
+        if XGBOOST_VERSION < Version("1.4.0"):
             warnings.warn(LEGACY_WARNING)
         return f(*args, **kwargs)
 

--- a/xgboost_ray/tests/test_sklearn.py
+++ b/xgboost_ray/tests/test_sklearn.py
@@ -28,7 +28,7 @@ distributed setting."""  # noqa: E501
 import numpy as np
 import xgboost as xgb
 import unittest
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 # import io
 # from contextlib import redirect_stdout, redirect_stderr
@@ -43,8 +43,8 @@ from xgboost_ray.sklearn import (RayXGBClassifier, RayXGBRegressor,
                                  RayXGBRFClassifier, RayXGBRFRegressor,
                                  RayXGBRanker)
 
-from xgboost_ray.main import (XGBOOST_LOOSE_VERSION, RayDMatrix, RayParams,
-                              train, predict)
+from xgboost_ray.main import (XGBOOST_VERSION, RayDMatrix, RayParams, train,
+                              predict)
 from xgboost_ray.matrix import RayShardingMode
 
 
@@ -135,7 +135,7 @@ class XGBoostRaySklearnTest(unittest.TestCase):
             ray_dmatrix_params={"sharding": RayShardingMode.BATCH})
 
     # ray: added for legacy CI test
-    @unittest.skipIf(XGBOOST_LOOSE_VERSION < LooseVersion("1.0.0"),
+    @unittest.skipIf(XGBOOST_VERSION < Version("1.0.0"),
                      f"not supported in xgb version {xgb.__version__}")
     def test_binary_rf_classification(self):
         self.run_binary_classification(RayXGBRFClassifier)
@@ -194,7 +194,7 @@ class XGBoostRaySklearnTest(unittest.TestCase):
         assert proba.shape[0] == X.shape[0]
         assert proba.shape[1] == cls.n_classes_
 
-    @unittest.skipIf(XGBOOST_LOOSE_VERSION < LooseVersion("1.4.0"),
+    @unittest.skipIf(XGBOOST_VERSION < Version("1.4.0"),
                      f"not supported in xgb version {xgb.__version__}")
     def test_best_ntree_limit(self):
         self._init_ray()
@@ -307,13 +307,13 @@ class XGBoostRaySklearnTest(unittest.TestCase):
         dump = bst.get_booster().get_dump(dump_format="json")
         assert len(dump) == 16
 
-        if XGBOOST_LOOSE_VERSION != LooseVersion("0.90"):
+        if XGBOOST_VERSION != Version("0.90"):
             reg = RayXGBRFRegressor(n_estimators=4)
             bst = reg.fit(X=boston["data"], y=boston["target"])
             dump = bst.get_booster().get_dump(dump_format="json")
             assert len(dump) == 4
 
-            if XGBOOST_LOOSE_VERSION >= LooseVersion("1.6.0"):
+            if XGBOOST_VERSION >= Version("1.6.0"):
                 config = json.loads(bst.get_booster().save_config())
                 assert (int(config["learner"]["gradient_booster"][
                     "gbtree_model_param"]["num_parallel_tree"]) == 4)
@@ -351,7 +351,7 @@ class XGBoostRaySklearnTest(unittest.TestCase):
             assert mean_squared_error(preds3, labels) < 25
             assert mean_squared_error(preds4, labels) < 350
 
-    @unittest.skipIf(XGBOOST_LOOSE_VERSION < LooseVersion("1.0.0"),
+    @unittest.skipIf(XGBOOST_VERSION < Version("1.0.0"),
                      f"not supported in xgb version {xgb.__version__}")
     def run_boston_housing_rf_regression(self, tree_method):
         from sklearn.metrics import mean_squared_error
@@ -523,7 +523,7 @@ class XGBoostRaySklearnTest(unittest.TestCase):
                     if p != l]) * 1.0 / len(te_l))
         assert err < 0.5
 
-    @unittest.skipIf(XGBOOST_LOOSE_VERSION < LooseVersion("1.0.0"),
+    @unittest.skipIf(XGBOOST_VERSION < Version("1.0.0"),
                      f"not supported in xgb version {xgb.__version__}")
     def test_sklearn_random_state(self):
         self._init_ray()
@@ -538,7 +538,7 @@ class XGBoostRaySklearnTest(unittest.TestCase):
         clf = RayXGBClassifier(random_state=random_state)
         assert isinstance(clf.get_xgb_params()["random_state"], int)
 
-    @unittest.skipIf(XGBOOST_LOOSE_VERSION < LooseVersion("1.0.0"),
+    @unittest.skipIf(XGBOOST_VERSION < Version("1.0.0"),
                      f"not supported in xgb version {xgb.__version__}")
     def test_sklearn_n_jobs(self):
         self._init_ray()
@@ -549,7 +549,7 @@ class XGBoostRaySklearnTest(unittest.TestCase):
         clf = RayXGBClassifier(n_jobs=2)
         assert clf.get_xgb_params()["n_jobs"] == 2
 
-    @unittest.skipIf(XGBOOST_LOOSE_VERSION < LooseVersion("1.3.0"),
+    @unittest.skipIf(XGBOOST_VERSION < Version("1.3.0"),
                      f"not supported in xgb version {xgb.__version__}")
     def test_parameters_access(self):
         self._init_ray()
@@ -615,7 +615,7 @@ class XGBoostRaySklearnTest(unittest.TestCase):
         clf.n_jobs = -1
         clone(clf)
 
-    @unittest.skipIf(XGBOOST_LOOSE_VERSION < LooseVersion("1.0.0"),
+    @unittest.skipIf(XGBOOST_VERSION < Version("1.0.0"),
                      f"not supported in xgb version {xgb.__version__}")
     def test_sklearn_get_default_params(self):
         self._init_ray()
@@ -630,7 +630,7 @@ class XGBoostRaySklearnTest(unittest.TestCase):
         cls.fit(X[:4, ...], y[:4, ...])
         assert cls.get_params()["base_score"] is not None
 
-    @unittest.skipIf(XGBOOST_LOOSE_VERSION < LooseVersion("1.1.0"),
+    @unittest.skipIf(XGBOOST_VERSION < Version("1.1.0"),
                      f"not supported in xgb version {xgb.__version__}")
     def test_validation_weights_xgbmodel(self):
         self._init_ray()
@@ -802,7 +802,7 @@ class XGBoostRaySklearnTest(unittest.TestCase):
                 xgb_model = xgb.XGBModel()
                 xgb_model.load_model(model_path)
 
-    @unittest.skipIf(XGBOOST_LOOSE_VERSION < LooseVersion("1.3.0"),
+    @unittest.skipIf(XGBOOST_VERSION < Version("1.3.0"),
                      f"not supported in xgb version {xgb.__version__}")
     def test_save_load_model(self):
         self._init_ray()
@@ -956,7 +956,7 @@ class XGBoostRaySklearnTest(unittest.TestCase):
             assert np.any(pred1 != pred2)
             assert log_loss1 > log_loss2
 
-    @unittest.skipIf(XGBOOST_LOOSE_VERSION < LooseVersion("1.0.0"),
+    @unittest.skipIf(XGBOOST_VERSION < Version("1.0.0"),
                      f"not supported in xgb version {xgb.__version__}")
     def test_constraint_parameters(self):
         self._init_ray()
@@ -967,7 +967,7 @@ class XGBoostRaySklearnTest(unittest.TestCase):
         reg.fit(X, y)
 
         config = json.loads(reg.get_booster().save_config())
-        if XGBOOST_LOOSE_VERSION >= LooseVersion("1.6.0"):
+        if XGBOOST_VERSION >= Version("1.6.0"):
             assert (config["learner"]["gradient_booster"]["updater"][
                 "grow_histmaker"]["train_param"]["interaction_constraints"] ==
                     "[[0, 1], [2, 3, 4]]")
@@ -1176,12 +1176,12 @@ class XGBoostRaySklearnTest(unittest.TestCase):
 
         self.run_boost_from_prediction(tree_method)
 
-    @unittest.skipIf(XGBOOST_LOOSE_VERSION < LooseVersion("1.0.0"),
+    @unittest.skipIf(XGBOOST_VERSION < Version("1.0.0"),
                      f"not supported in xgb version {xgb.__version__}")
     def test_boost_from_prediction_hist(self):
         self.run_boost_from_prediction("hist")
 
-    @unittest.skipIf(XGBOOST_LOOSE_VERSION < LooseVersion("1.2.0"),
+    @unittest.skipIf(XGBOOST_VERSION < Version("1.2.0"),
                      f"not supported in xgb version {xgb.__version__}")
     def test_boost_from_prediction_approx(self):
         self.run_boost_from_prediction("approx")
@@ -1192,7 +1192,7 @@ class XGBoostRaySklearnTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.run_boost_from_prediction("exact")
 
-    @unittest.skipIf(XGBOOST_LOOSE_VERSION < LooseVersion("1.4.0"),
+    @unittest.skipIf(XGBOOST_VERSION < Version("1.4.0"),
                      f"not supported in xgb version {xgb.__version__}")
     def test_estimator_type(self):
         self._init_ray()

--- a/xgboost_ray/tests/test_sklearn_matrix.py
+++ b/xgboost_ray/tests/test_sklearn_matrix.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion
+from packaging.version import Version
 import numpy as np
 import unittest
 
@@ -10,10 +10,10 @@ from sklearn.model_selection import train_test_split
 from xgboost_ray.sklearn import (RayXGBClassifier, RayXGBRegressor)
 from xgboost_ray.main import RayDMatrix
 
-from xgboost_ray.main import XGBOOST_LOOSE_VERSION
+from xgboost_ray.main import XGBOOST_VERSION
 
-has_label_encoder = (XGBOOST_LOOSE_VERSION >= LooseVersion("1.0.0")
-                     and XGBOOST_LOOSE_VERSION < LooseVersion("1.6.0"))
+has_label_encoder = (XGBOOST_VERSION >= Version("1.0.0")
+                     and XGBOOST_VERSION < Version("1.6.0"))
 
 
 class XGBoostRaySklearnMatrixTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

This PR removes uses of `distutils.version.LooseVersion` in favor of `packaging.version.Version` at the suggestion of the deprecation warning generated when a user makes use of `LooseVersion`. This PR addresses one of the deprecation warnings identified in https://github.com/ray-project/ray/issues/27851. `distutils` [will be deprecated in Python 3.10 and 3.11, and removed entirely in 3.12](https://peps.python.org/pep-0632/).

## Changes

- Replaced `distutils.version.Version` with `packaging.version.Version` everywhere
- Added `packaging` as a dependency in `requirements-test.txt` and in `setup.py`

## Tests

I tested this on my local machine with `pytest` and all the tests that weren't skipped passed.