### PR TITLE
Add sort dataframe logic on qid

### DIFF
--- a/xgboost_ray/matrix.py
+++ b/xgboost_ray/matrix.py
@@ -227,6 +227,10 @@ class _RayDMatrixLoader:
         `label_upper_bound`
 
         """
+        # sort dataframe by qid if exists (required by DMatrix)
+        if self.qid and not local_data[self.qid].is_monotonic:
+            local_data = local_data.sort_values([self.qid])
+
         exclude_cols: Set[str] = set()  # Exclude these columns from `x`
 
         label, exclude = data_source.get_column(local_data, self.label)
@@ -349,11 +353,6 @@ class _CentralRayDMatrixLoader(_RayDMatrixLoader):
         # yet. Instead, we'll be selecting the rows below.
         local_df = data_source.load_data(
             self.data, ignore=self.ignore, indices=None, **self.kwargs)
-
-        # sort dataframe by qid if exists (required by DMatrix)
-        if self.qid and not local_df[self.qid].is_monotonic:
-            local_df = local_df.sort_values([self.qid])
-
         x, y, w, b, ll, lu, qid = self._split_dataframe(
             local_df, data_source=data_source)
 

--- a/xgboost_ray/matrix.py
+++ b/xgboost_ray/matrix.py
@@ -55,6 +55,11 @@ def ensure_sorted_by_qid(df: pd.DataFrame, qid: Data) -> Tuple[Union[np.array, s
     elif isinstance(qid, np.ndarray):
         _qid = pd.Series(qid)
     elif isinstance(qid, pd.DataFrame):
+        if len(df.shape) != 2 and df.shape[1] != 1:
+            raise ValueError(
+                f"qid argument of type pd.DataFrame is expected to contains only 1 column of data "
+                f"but the qid passed in is of shape {df.shape}."
+            )
         _qid = qid.iloc[:, 0]
     elif isinstance(qid, pd.Series):
         _qid = qid

--- a/xgboost_ray/matrix.py
+++ b/xgboost_ray/matrix.py
@@ -48,7 +48,8 @@ def concat_dataframes(dfs: List[Optional[pd.DataFrame]]):
     return pd.concat(filtered, ignore_index=True, copy=False)
 
 
-def ensure_sorted_by_qid(df: pd.DataFrame, qid: Data) -> Tuple[Union[np.array, str], pd.DataFrame]:
+def ensure_sorted_by_qid(df: pd.DataFrame, qid: Data
+                         ) -> Tuple[Union[np.array, str], pd.DataFrame]:
     _qid: pd.Series = None
     if isinstance(qid, str):
         _qid = df[qid]
@@ -58,8 +59,7 @@ def ensure_sorted_by_qid(df: pd.DataFrame, qid: Data) -> Tuple[Union[np.array, s
         if len(df.shape) != 2 and df.shape[1] != 1:
             raise ValueError(
                 f"qid argument of type pd.DataFrame is expected to contains only 1 column of data "
-                f"but the qid passed in is of shape {df.shape}."
-            )
+                f"but the qid passed in is of shape {df.shape}.")
         _qid = qid.iloc[:, 0]
     elif isinstance(qid, pd.Series):
         _qid = qid

--- a/xgboost_ray/matrix.py
+++ b/xgboost_ray/matrix.py
@@ -228,7 +228,7 @@ class _RayDMatrixLoader:
 
         """
         # sort dataframe by qid if exists (required by DMatrix)
-        if self.qid and not local_data[self.qid].is_monotonic:
+        if self.qid is not None and not local_data[self.qid].is_monotonic:
             local_data = local_data.sort_values([self.qid])
 
         exclude_cols: Set[str] = set()  # Exclude these columns from `x`

--- a/xgboost_ray/matrix.py
+++ b/xgboost_ray/matrix.py
@@ -57,9 +57,9 @@ def ensure_sorted_by_qid(df: pd.DataFrame, qid: Data
         _qid = pd.Series(qid)
     elif isinstance(qid, pd.DataFrame):
         if len(df.shape) != 2 and df.shape[1] != 1:
-            raise ValueError(
-                f"qid argument of type pd.DataFrame is expected to contains only 1 column of data "
-                f"but the qid passed in is of shape {df.shape}.")
+            raise ValueError(f"qid argument of type pd.DataFrame is expected"
+                             "to contains only 1 column of data "
+                             f"but the qid passed in is of shape {df.shape}.")
         _qid = qid.iloc[:, 0]
     elif isinstance(qid, pd.Series):
         _qid = qid

--- a/xgboost_ray/matrix.py
+++ b/xgboost_ray/matrix.py
@@ -349,6 +349,11 @@ class _CentralRayDMatrixLoader(_RayDMatrixLoader):
         # yet. Instead, we'll be selecting the rows below.
         local_df = data_source.load_data(
             self.data, ignore=self.ignore, indices=None, **self.kwargs)
+
+        # sort dataframe by qid if exists (required by DMatrix)
+        if self.qid and not local_df[self.qid].is_monotonic:
+            local_df = local_df.sort_values([self.qid])
+
         x, y, w, b, ll, lu, qid = self._split_dataframe(
             local_df, data_source=data_source)
 

--- a/xgboost_ray/tests/test_matrix.py
+++ b/xgboost_ray/tests/test_matrix.py
@@ -1,7 +1,7 @@
+import inspect
 import os
 import tempfile
 import unittest
-from packaging.version import Version
 import xgboost as xgb
 
 import numpy as np
@@ -10,7 +10,6 @@ import pandas as pd
 import ray
 
 from xgboost_ray import RayDMatrix
-from xgboost_ray.main import XGBOOST_VERSION
 from xgboost_ray.matrix import (concat_dataframes, RayShardingMode,
                                 _get_sharding_indices)
 
@@ -359,7 +358,7 @@ class XGBoostRayDMatrixTest(unittest.TestCase):
             label_lower_bound=label_lower_bound,
             label_upper_bound=label_upper_bound)
 
-    @unittest.skipIf(XGBOOST_VERSION <= Version("0.9.0"),
+    @unittest.skipIf("qid" not in inspect.signature(xgb.DMatrix).parameters,
                      f"not supported in xgb version {xgb.__version__}")
     def testQidSortedBehaviorXGBoost(self):
         """Test that data with unsorted qid is sorted in RayDMatrix"""
@@ -380,7 +379,7 @@ class XGBoostRayDMatrixTest(unittest.TestCase):
         params = mat.get_data(rank=0, num_actors=1)
         DMatrix(**params)
 
-    @unittest.skipIf(XGBOOST_VERSION <= Version("0.9.0"),
+    @unittest.skipIf("qid" not in inspect.signature(xgb.DMatrix).parameters,
                      f"not supported in xgb version {xgb.__version__}")
     def testQidSortedParquet(self):
         from xgboost import DMatrix

--- a/xgboost_ray/tests/test_matrix.py
+++ b/xgboost_ray/tests/test_matrix.py
@@ -356,6 +356,56 @@ class XGBoostRayDMatrixTest(unittest.TestCase):
             label_lower_bound=label_lower_bound,
             label_upper_bound=label_upper_bound)
 
+    def testQidSortedBehaviorXGBoost(self):
+        """Test that data with unsorted qid is sorted in RayDMatrix"""
+        in_x = self.x
+        in_y = self.y
+        unsorted_qid = np.array([1, 2] * 16)
+
+        from xgboost import DMatrix
+        with self.assertRaises(ValueError):
+            _ = DMatrix(**{
+                "data": in_x,
+                "label": in_y,
+                "qid": unsorted_qid
+            })
+        _ = DMatrix(**{
+            "data": in_x,
+            "label": in_y,
+            "qid": np.sort(unsorted_qid)
+        })  # no exception
+        # test RayDMatrix handles sorting automatically
+        mat = RayDMatrix(in_x, in_y, qid=unsorted_qid)
+        params = mat.get_data(rank=0, num_actors=1)
+        _ = DMatrix(**params)
+
+    def testQidSortedParquet(self):
+        from xgboost import DMatrix
+        with tempfile.TemporaryDirectory() as dir:
+            parquet_file1 = os.path.join(dir, "file1.parquet")
+            parquet_file2 = os.path.join(dir, "file2.parquet")
+
+            unsorted_qid1 = np.array([2, 4] * 16)
+            unsorted_qid2 = np.array([1, 3] * 16)
+
+            # parquet 1
+            data_df = pd.DataFrame(self.x, columns=["a", "b", "c", "d"])
+            data_df["label"] = pd.Series(self.y)
+            data_df["group"] = pd.Series(unsorted_qid1)
+            data_df.to_parquet(parquet_file1)
+            # parquet 2
+            data_df = pd.DataFrame(self.x, columns=["a", "b", "c", "d"])
+            data_df["label"] = pd.Series(self.y)
+            data_df["group"] = pd.Series(unsorted_qid2)
+            data_df.to_parquet(parquet_file2)
+            mat = RayDMatrix([parquet_file1, parquet_file2],
+                             columns=["a", "b", "c", "d",
+                                      "label", "group"],
+                             label="label",
+                             qid="group")
+            params = mat.get_data(rank=0, num_actors=1)
+            _ = DMatrix(**params)
+
 
 if __name__ == "__main__":
     import pytest

--- a/xgboost_ray/tests/test_matrix.py
+++ b/xgboost_ray/tests/test_matrix.py
@@ -29,7 +29,7 @@ class XGBoostRayDMatrixTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        ray.init(num_cpus=1, local_mode=True)
+        ray.init(local_mode=True)
 
     @classmethod
     def tearDownClass(cls):

--- a/xgboost_ray/tests/test_matrix.py
+++ b/xgboost_ray/tests/test_matrix.py
@@ -364,12 +364,8 @@ class XGBoostRayDMatrixTest(unittest.TestCase):
 
         from xgboost import DMatrix
         with self.assertRaises(ValueError):
-            _ = DMatrix(**{
-                "data": in_x,
-                "label": in_y,
-                "qid": unsorted_qid
-            })
-        _ = DMatrix(**{
+            DMatrix(**{"data": in_x, "label": in_y, "qid": unsorted_qid})
+        DMatrix(**{
             "data": in_x,
             "label": in_y,
             "qid": np.sort(unsorted_qid)
@@ -377,7 +373,7 @@ class XGBoostRayDMatrixTest(unittest.TestCase):
         # test RayDMatrix handles sorting automatically
         mat = RayDMatrix(in_x, in_y, qid=unsorted_qid)
         params = mat.get_data(rank=0, num_actors=1)
-        _ = DMatrix(**params)
+        DMatrix(**params)
 
     def testQidSortedParquet(self):
         from xgboost import DMatrix
@@ -398,13 +394,13 @@ class XGBoostRayDMatrixTest(unittest.TestCase):
             data_df["label"] = pd.Series(self.y)
             data_df["group"] = pd.Series(unsorted_qid2)
             data_df.to_parquet(parquet_file2)
-            mat = RayDMatrix([parquet_file1, parquet_file2],
-                             columns=["a", "b", "c", "d",
-                                      "label", "group"],
-                             label="label",
-                             qid="group")
+            mat = RayDMatrix(
+                [parquet_file1, parquet_file2],
+                columns=["a", "b", "c", "d", "label", "group"],
+                label="label",
+                qid="group")
             params = mat.get_data(rank=0, num_actors=1)
-            _ = DMatrix(**params)
+            DMatrix(**params)
 
 
 if __name__ == "__main__":

--- a/xgboost_ray/tests/test_matrix.py
+++ b/xgboost_ray/tests/test_matrix.py
@@ -1,6 +1,8 @@
 import os
 import tempfile
 import unittest
+from packaging.version import Version
+import xgboost as xgb
 
 import numpy as np
 import pandas as pd
@@ -8,6 +10,7 @@ import pandas as pd
 import ray
 
 from xgboost_ray import RayDMatrix
+from xgboost_ray.main import XGBOOST_VERSION
 from xgboost_ray.matrix import (concat_dataframes, RayShardingMode,
                                 _get_sharding_indices)
 
@@ -356,6 +359,8 @@ class XGBoostRayDMatrixTest(unittest.TestCase):
             label_lower_bound=label_lower_bound,
             label_upper_bound=label_upper_bound)
 
+    @unittest.skipIf(XGBOOST_VERSION < Version("0.9.0"),
+                     f"not supported in xgb version {xgb.__version__}")
     def testQidSortedBehaviorXGBoost(self):
         """Test that data with unsorted qid is sorted in RayDMatrix"""
         in_x = self.x
@@ -375,6 +380,8 @@ class XGBoostRayDMatrixTest(unittest.TestCase):
         params = mat.get_data(rank=0, num_actors=1)
         DMatrix(**params)
 
+    @unittest.skipIf(XGBOOST_VERSION < Version("0.9.0"),
+                     f"not supported in xgb version {xgb.__version__}")
     def testQidSortedParquet(self):
         from xgboost import DMatrix
         with tempfile.TemporaryDirectory() as dir:

--- a/xgboost_ray/tests/test_matrix.py
+++ b/xgboost_ray/tests/test_matrix.py
@@ -359,7 +359,7 @@ class XGBoostRayDMatrixTest(unittest.TestCase):
             label_lower_bound=label_lower_bound,
             label_upper_bound=label_upper_bound)
 
-    @unittest.skipIf(XGBOOST_VERSION < Version("0.9.0"),
+    @unittest.skipIf(XGBOOST_VERSION <= Version("0.9.0"),
                      f"not supported in xgb version {xgb.__version__}")
     def testQidSortedBehaviorXGBoost(self):
         """Test that data with unsorted qid is sorted in RayDMatrix"""
@@ -380,7 +380,7 @@ class XGBoostRayDMatrixTest(unittest.TestCase):
         params = mat.get_data(rank=0, num_actors=1)
         DMatrix(**params)
 
-    @unittest.skipIf(XGBOOST_VERSION < Version("0.9.0"),
+    @unittest.skipIf(XGBOOST_VERSION <= Version("0.9.0"),
                      f"not supported in xgb version {xgb.__version__}")
     def testQidSortedParquet(self):
         from xgboost import DMatrix


### PR DESCRIPTION
If qid is provided, xgb.DMatrix [requires data to be sorted by qid - see data.cc](https://github.com/dmlc/xgboost/blob/master/src/data/data.cc#L486):
https://github.com/ray-project/xgboost_ray/blob/master/xgboost_ray/matrix.py#L351

draft to add auto sorting of dataframe if qid is given and dataframe is not already sorted by qid 