### PR TITLE
Switch from 3.6 to 3.9 in tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,14 +33,14 @@ jobs:
     timeout-minutes: 160
     strategy:
       matrix:
-        python-version: [3.6.9, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
         include:
-          - python-version: 3.6.9
-            ray-wheel: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp36-cp36m-manylinux2014_x86_64.whl
           - python-version: 3.7
             ray-wheel: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp37-cp37m-manylinux2014_x86_64.whl
           - python-version: 3.8
             ray-wheel: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl
+          - python-version: 3.9
+            ray-wheel: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -77,7 +77,7 @@ jobs:
     timeout-minutes: 160
     strategy:
       matrix:
-        python-version: [3.6.9, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -116,7 +116,7 @@ jobs:
     timeout-minutes: 160
     strategy:
       matrix:
-        python-version: [3.6.9, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -160,12 +160,14 @@ jobs:
     strategy:
       matrix:
         # no new versions for xgboost are published for 3.6
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
         include:
           - python-version: 3.7
             ray-wheel: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp37-cp37m-manylinux2014_x86_64.whl
           - python-version: 3.8
             ray-wheel: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl
+          - python-version: 3.9
+            ray-wheel: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -220,7 +222,7 @@ jobs:
     timeout-minutes: 160
     strategy:
       matrix:
-        python-version: [3.6.9]
+        python-version: [3.7]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Signed-off-by: Antoni Baum <antoni.baum@protonmail.com>

3.6 is no longer supported in Github Actions.