### PR TITLE
Add special case in `_get_tune_resources`

### DIFF
--- a/xgboost_ray/tune.py
+++ b/xgboost_ray/tune.py
@@ -122,7 +122,8 @@ def _get_tune_resources(num_actors: int, cpus_per_actor: int,
         bundles = [head_bundle] + child_bundles
         placement_options = placement_options or {}
         placement_options.setdefault("strategy", "PACK")
-        # Special case, same as in ray.air.ScalingConfig.as_placement_group_factory
+        # Special case, same as in
+        # ray.air.ScalingConfig.as_placement_group_factory
         # TODO remove after Ray 2.3 is out
         if placement_options.get("_max_cpu_fraction_per_node", None) is None:
             placement_options.pop("_max_cpu_fraction_per_node", None)

--- a/xgboost_ray/tune.py
+++ b/xgboost_ray/tune.py
@@ -122,6 +122,10 @@ def _get_tune_resources(num_actors: int, cpus_per_actor: int,
         bundles = [head_bundle] + child_bundles
         placement_options = placement_options or {}
         placement_options.setdefault("strategy", "PACK")
+        # Special case, same as in ray.air.ScalingConfig.as_placement_group_factory
+        # TODO remove after Ray 2.3 is out
+        if placement_options.get("_max_cpu_fraction_per_node", None) is None:
+            placement_options.pop("_max_cpu_fraction_per_node", None)
         placement_group_factory = PlacementGroupFactory(
             bundles, **placement_options)
 


### PR DESCRIPTION
Signed-off-by: Antoni Baum <antoni.baum@protonmail.com>

If `_max_cpu_fraction_per_node` is None and passed to `placement_group`, an exception will be thrown. Currently, code in Ray doesn't discard that key if its None before passing it to `xgboost_ray.RayParams`. This will be fixed properly in Ray (https://github.com/ray-project/ray/pull/30977), but in the meantime, we add a special case here to ensure that Ray 2.2 works.