### PR TITLE
Fix _ray_get_act_cpus and set nthread in param passed to DMatrix creation

### DIFF
--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -296,7 +296,7 @@ def _ray_get_actor_cpus():
         for key in resource_ids.keys():
             if key.startswith("CPU"):
                 return resource_ids[key]
-        return None
+        return 1
 
 
 def _ray_get_cluster_cpus():

--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -293,7 +293,10 @@ def _ray_get_actor_cpus():
             return sum(cpu[1] for cpu in resource_ids["CPU"])
     else:
         resource_ids = ray.get_runtime_context().get_assigned_resources()
-        return resource_ids.get("CPU")
+        for key in resource_ids.keys():
+            if key.startswith("CPU"):
+                return resource_ids[key]
+        return None
 
 
 def _ray_get_cluster_cpus():
@@ -599,6 +602,8 @@ class RayXGBoostActor:
         else:
             self._local_n[data] = len(param["data"])
 
+        # set nthread for dmatrix conversion
+        param["nthread"] = int(_ray_get_actor_cpus())
         self._data[data] = param
 
         self._distributed_callbacks.after_data_loading(self, data)

--- a/xgboost_ray/tests/test_client.py
+++ b/xgboost_ray/tests/test_client.py
@@ -50,6 +50,7 @@ def test_simple_modin(start_client_server_5_cpus):
 def test_client_actor_cpus(start_client_server_5_cpus):
     assert ray.util.client.ray.is_connected()
     from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
+
     @ray.remote
     class DummyTrainActor():
         def test(self):
@@ -61,8 +62,10 @@ def test_client_actor_cpus(start_client_server_5_cpus):
 
     pg = ray.util.placement_group([{"CPU": 2}])
     ray.get(pg.ready())
-    actor2 = DummyTrainActor.options(num_cpus=2,
-        scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg)).remote()
+    actor2 = DummyTrainActor.options(
+        num_cpus=2,
+        scheduling_strategy=PlacementGroupSchedulingStrategy(
+            placement_group=pg)).remote()
     assert ray.get(actor2.test.remote()) == 2
 
 

--- a/xgboost_ray/tests/test_end_to_end.py
+++ b/xgboost_ray/tests/test_end_to_end.py
@@ -136,6 +136,24 @@ class XGBoostRayEndToEndTest(unittest.TestCase):
         pred_test = bst.predict(test_X)
         self.assertSequenceEqual(test_y_second, list(pred_test))
 
+    def test_client_actor_cpus(self):
+        ray.init(num_cpus=5, num_gpus=0)
+        from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
+        @ray.remote
+        class DummyTrainActor():
+            def test(self):
+                import xgboost_ray
+                return xgboost_ray.main._ray_get_actor_cpus()
+
+        actor = DummyTrainActor.options(num_cpus=2).remote()
+        assert ray.get(actor.test.remote()) == 2
+
+        pg = ray.util.placement_group([{"CPU": 2}])
+        ray.get(pg.ready())
+        actor2 = DummyTrainActor.options(num_cpus=2,
+            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg)).remote()
+        assert ray.get(actor2.test.remote()) == 2
+
     def _testJointTraining(self,
                            sharding=RayShardingMode.INTERLEAVED,
                            softprob=False):


### PR DESCRIPTION
This pr closes #266

_ray_get_act_cpus  did not get the correct number set for CPU in actors, because when placement group is used, the resource name changes. In addition, set this number as nthread in param which is used to create DMatrix. @Yard1 