### PR TITLE
Mark Ray Dataset as always having enough shards

### DIFF
--- a/xgboost_ray/matrix.py
+++ b/xgboost_ray/matrix.py
@@ -496,6 +496,11 @@ class _DistributedRayDMatrixLoader(_RayDMatrixLoader):
     def assert_enough_shards_for_actors(self, num_actors: int):
         data_source = self.get_data_source()
 
+        # Ray Datasets will be automatically split to match the number
+        # of actors.
+        if isinstance(data_source, RayDataset):
+            return
+
         max_num_shards = self._cached_n or data_source.get_n(self.data)
         if num_actors > max_num_shards:
             raise RuntimeError(


### PR DESCRIPTION
Make `assert_enough_shards_for_actors` always pass if Ray Datasets are used, as they will be split to match the number of actors during loading.