### PR TITLE
Add QuantileDMatrix support

### DIFF
--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -319,6 +319,7 @@ def _set_omp_num_threads():
             del os.environ["OMP_NUM_THREADS"]
     return int(float(os.environ.get("OMP_NUM_THREADS", "0.0")))
 
+
 def _prepare_dmatrix_params(param: Dict) -> Dict:
     dm_param = {
         "data": concat_dataframes(param["data"]),
@@ -327,10 +328,8 @@ def _prepare_dmatrix_params(param: Dict) -> Dict:
         "feature_weights": concat_dataframes(param["feature_weights"]),
         "qid": concat_dataframes(param["qid"]),
         "base_margin": concat_dataframes(param["base_margin"]),
-        "label_lower_bound": concat_dataframes(
-            param["label_lower_bound"]),
-        "label_upper_bound": concat_dataframes(
-            param["label_upper_bound"]),
+        "label_lower_bound": concat_dataframes(param["label_lower_bound"]),
+        "label_upper_bound": concat_dataframes(param["label_upper_bound"]),
     }
     return dm_param
 

--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -319,22 +319,26 @@ def _set_omp_num_threads():
             del os.environ["OMP_NUM_THREADS"]
     return int(float(os.environ.get("OMP_NUM_THREADS", "0.0")))
 
+def _prepare_dmatrix_params(param: Dict) -> Dict:
+    dm_param = {
+        "data": concat_dataframes(param["data"]),
+        "label": concat_dataframes(param["label"]),
+        "weight": concat_dataframes(param["weight"]),
+        "feature_weights": concat_dataframes(param["feature_weights"]),
+        "qid": concat_dataframes(param["qid"]),
+        "base_margin": concat_dataframes(param["base_margin"]),
+        "label_lower_bound": concat_dataframes(
+            param["label_lower_bound"]),
+        "label_upper_bound": concat_dataframes(
+            param["label_upper_bound"]),
+    }
+    return dm_param
+
 
 def _get_dmatrix(data: RayDMatrix, param: Dict) -> xgb.DMatrix:
     if QUANTILE_AVAILABLE and isinstance(data, RayQuantileDMatrix):
         if isinstance(param["data"], list):
-            qdm_param = {
-                "data": concat_dataframes(param["data"]),
-                "label": concat_dataframes(param["label"]),
-                "weight": concat_dataframes(param["weight"]),
-                "feature_weights": concat_dataframes(param["feature_weights"]),
-                "qid": concat_dataframes(param["qid"]),
-                "base_margin": concat_dataframes(param["base_margin"]),
-                "label_lower_bound": concat_dataframes(
-                    param["label_lower_bound"]),
-                "label_upper_bound": concat_dataframes(
-                    param["label_upper_bound"]),
-            }
+            qdm_param = _prepare_dmatrix_params(param)
             param.update(qdm_param)
         if data.enable_categorical is not None:
             param["enable_categorical"] = data.enable_categorical
@@ -373,18 +377,7 @@ def _get_dmatrix(data: RayDMatrix, param: Dict) -> xgb.DMatrix:
         matrix = xgb.DeviceQuantileDMatrix(it, **dm_param)
     else:
         if isinstance(param["data"], list):
-            dm_param = {
-                "data": concat_dataframes(param["data"]),
-                "label": concat_dataframes(param["label"]),
-                "weight": concat_dataframes(param["weight"]),
-                "feature_weights": concat_dataframes(param["feature_weights"]),
-                "qid": concat_dataframes(param["qid"]),
-                "base_margin": concat_dataframes(param["base_margin"]),
-                "label_lower_bound": concat_dataframes(
-                    param["label_lower_bound"]),
-                "label_upper_bound": concat_dataframes(
-                    param["label_upper_bound"]),
-            }
+            dm_param = _prepare_dmatrix_params(param)
             param.update(dm_param)
 
         ll = param.pop("label_lower_bound", None)

--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -675,7 +675,6 @@ class RayXGBoostActor:
                 with _RabitContext(str(id(self)), rabit_args):
 
                     local_dtrain = _get_dmatrix(dtrain, self._data[dtrain])
-                    del self._data[dtrain]
 
                     if not local_dtrain.get_label().size:
                         raise RuntimeError(
@@ -687,9 +686,7 @@ class RayXGBoostActor:
                     local_evals = []
                     for deval, name in evals:
                         local_evals.append((_get_dmatrix(
-                            deval, self._data[deval], local_dtrain), name))
-                        del self._data[deval]
-
+                            deval, self._data[deval]), name))
                     if LEGACY_CALLBACK:
                         for xgb_callback in kwargs.get("callbacks", []):
                             if isinstance(xgb_callback, TrainingCallback):

--- a/xgboost_ray/matrix.py
+++ b/xgboost_ray/matrix.py
@@ -503,6 +503,11 @@ class _DistributedRayDMatrixLoader(_RayDMatrixLoader):
     def assert_enough_shards_for_actors(self, num_actors: int):
         data_source = self.get_data_source()
 
+        # Ray Datasets will be automatically split to match the number
+        # of actors.
+        if isinstance(data_source, RayDataset):
+            return
+
         max_num_shards = self._cached_n or data_source.get_n(self.data)
         if num_actors > max_num_shards:
             raise RuntimeError(

--- a/xgboost_ray/matrix.py
+++ b/xgboost_ray/matrix.py
@@ -37,6 +37,13 @@ except ImportError:
     DataIter = object
     LEGACY_MATRIX = True
 
+try:
+    from xgboost.core import QuantileDmatrix
+    QUANTILE_AVAILABLE = True
+except ImportError:
+    QuantileDmatrix = object
+    QUANTILE_AVAILABLE = False
+
 if TYPE_CHECKING:
     from xgboost_ray.xgb import xgboost as xgb
 
@@ -496,11 +503,6 @@ class _DistributedRayDMatrixLoader(_RayDMatrixLoader):
     def assert_enough_shards_for_actors(self, num_actors: int):
         data_source = self.get_data_source()
 
-        # Ray Datasets will be automatically split to match the number
-        # of actors.
-        if isinstance(data_source, RayDataset):
-            return
-
         max_num_shards = self._cached_n or data_source.get_n(self.data)
         if num_actors > max_num_shards:
             raise RuntimeError(
@@ -873,6 +875,11 @@ class RayDMatrix:
 
     def __eq__(self, other):
         return self.__hash__() == other.__hash__()
+
+
+class RayQuantileDMatrix(RayDMatrix):
+    """Currently just a thin wrapper for type detection"""
+    pass
 
 
 class RayDeviceQuantileDMatrix(RayDMatrix):


### PR DESCRIPTION
xgboost 1.7.0 has extended quantile dmatrix to CPU, and unified the API. Now DeviceQuantileDMatrix is deprecated. This PR adds support for QuantileDMatrix by adding a thin wrapper.