### PR TITLE
Fix sklearn tests

### DIFF
--- a/xgboost_ray/tests/test_sklearn.py
+++ b/xgboost_ray/tests/test_sklearn.py
@@ -976,10 +976,8 @@ class XGBoostRaySklearnTest(unittest.TestCase):
         reg.fit(X, y)
 
         config = json.loads(reg.get_booster().save_config())
-        if XGBOOST_VERSION > Version("1.7.4"):
-            assert (config["learner"]["gradient_booster"]["tree_train_param"][
-                "interaction_constraints"] == "[[0, 1], [2, 3, 4]]")
-        elif XGBOOST_VERSION >= Version("1.6.0"):
+
+        if XGBOOST_VERSION >= Version("1.6.0"):
             assert (config["learner"]["gradient_booster"]["updater"][
                 "grow_histmaker"]["train_param"]["interaction_constraints"] ==
                     "[[0, 1], [2, 3, 4]]")


### PR DESCRIPTION
This test reverts part of https://github.com/ray-project/xgboost_ray/pull/276. It seems like the naming changes have been reverted on xgboost master, leading to failures in our sklearn tests.