### PR TITLE
Repartition Ray dataset if number of shards is too small

### DIFF
--- a/xgboost_ray/data_sources/data_source.py
+++ b/xgboost_ray/data_sources/data_source.py
@@ -34,6 +34,7 @@ class DataSource:
 
     supports_central_loading = True
     supports_distributed_loading = False
+    needs_partitions = True
 
     @staticmethod
     def is_data_type(data: Any, filetype: Optional[RayFileType] = None) -> bool:
@@ -127,11 +128,6 @@ class DataSource:
         elif column is not None:
             return cls.convert_to_series(column), None
         return column, None
-
-    @staticmethod
-    def repartition(data: Any, num_partitions: int) -> Optional[Any]:
-        """Repartition dataset, if possible."""
-        return None
 
     @staticmethod
     def get_n(data: Any):

--- a/xgboost_ray/data_sources/data_source.py
+++ b/xgboost_ray/data_sources/data_source.py
@@ -129,6 +129,11 @@ class DataSource:
         return column, None
 
     @staticmethod
+    def repartition(data: Any, num_partitions: int) -> Optional[Any]:
+        """Repartition dataset, if possible."""
+        return None
+
+    @staticmethod
     def get_n(data: Any):
         """Get length of data source partitions for sharding."""
         return len(data)

--- a/xgboost_ray/data_sources/ray_dataset.py
+++ b/xgboost_ray/data_sources/ray_dataset.py
@@ -102,7 +102,14 @@ class RayDataset(DataSource):
         }
 
     @staticmethod
-    def get_n(data: Any):
+    def repartition(
+        data: "ray.data.dataset.Dataset", num_partitions: int
+    ) -> "ray.data.dataset.Dataset":
+        """Repartition dataset, if possible."""
+        return data.repartition(num_partitions)
+
+    @staticmethod
+    def get_n(data: "ray.data.dataset.Dataset"):
         """
         Return number of distributed blocks.
         """

--- a/xgboost_ray/data_sources/ray_dataset.py
+++ b/xgboost_ray/data_sources/ray_dataset.py
@@ -34,6 +34,7 @@ class RayDataset(DataSource):
 
     supports_central_loading = True
     supports_distributed_loading = True
+    needs_partitions = True
 
     @staticmethod
     def is_data_type(data: Any, filetype: Optional[RayFileType] = None) -> bool:
@@ -100,13 +101,6 @@ class RayDataset(DataSource):
         return None, {
             i: [dataset_split] for i, dataset_split in enumerate(dataset_splits)
         }
-
-    @staticmethod
-    def repartition(
-        data: "ray.data.dataset.Dataset", num_partitions: int
-    ) -> "ray.data.dataset.Dataset":
-        """Repartition dataset, if possible."""
-        return data.repartition(num_partitions)
 
     @staticmethod
     def get_n(data: "ray.data.dataset.Dataset"):

--- a/xgboost_ray/data_sources/ray_dataset.py
+++ b/xgboost_ray/data_sources/ray_dataset.py
@@ -34,7 +34,7 @@ class RayDataset(DataSource):
 
     supports_central_loading = True
     supports_distributed_loading = True
-    needs_partitions = True
+    needs_partitions = False
 
     @staticmethod
     def is_data_type(data: Any, filetype: Optional[RayFileType] = None) -> bool:

--- a/xgboost_ray/matrix.py
+++ b/xgboost_ray/matrix.py
@@ -430,19 +430,12 @@ class _CentralRayDMatrixLoader(_RayDMatrixLoader):
         data_source = self.get_data_source()
 
         max_num_shards = self._cached_n or data_source.get_n(self.data)
-        if num_actors > max_num_shards:
-            repartitioned = data_source.repartition(
-                self.data, num_partitions=num_actors
+        if num_actors > max_num_shards and data_source.needs_partitions:
+            raise RuntimeError(
+                f"Trying to shard data for {num_actors} actors, but the "
+                f"maximum number of shards (i.e. the number of data rows) "
+                f"is {max_num_shards}. Consider using fewer actors."
             )
-            if repartitioned:
-                self.data = repartitioned
-                self._cached_n = data_source.get_n(self.data)
-            else:
-                raise RuntimeError(
-                    f"Trying to shard data for {num_actors} actors, but the "
-                    f"maximum number of shards (i.e. the number of data rows) "
-                    f"is {max_num_shards}. Consider using fewer actors."
-                )
 
         # We're doing central data loading here, so we don't pass any indices,
         # yet. Instead, we'll be selecting the rows below.
@@ -572,22 +565,15 @@ class _DistributedRayDMatrixLoader(_RayDMatrixLoader):
             return
 
         max_num_shards = self._cached_n or data_source.get_n(self.data)
-        if num_actors > max_num_shards:
-            repartitioned = data_source.repartition(
-                self.data, num_partitions=num_actors
+        if num_actors > max_num_shards and data_source.needs_partitions:
+            raise RuntimeError(
+                f"Trying to shard data for {num_actors} actors, but the "
+                f"maximum number of shards is {max_num_shards}. If you "
+                f"want to shard the dataset by rows, consider "
+                f"centralized loading by passing `distributed=False` to "
+                f"the `RayDMatrix`. Otherwise consider using fewer actors "
+                f"or re-partitioning your data."
             )
-            if repartitioned:
-                self.data = repartitioned
-                self._cached_n = data_source.get_n(self.data)
-            else:
-                raise RuntimeError(
-                    f"Trying to shard data for {num_actors} actors, but the "
-                    f"maximum number of shards is {max_num_shards}. If you "
-                    f"want to shard the dataset by rows, consider "
-                    f"centralized loading by passing `distributed=False` to "
-                    f"the `RayDMatrix`. Otherwise consider using fewer actors "
-                    f"or re-partitioning your data."
-                )
 
     def assign_shards_to_actors(self, actors: Sequence[ActorHandle]) -> bool:
         if not isinstance(self.label, str):

--- a/xgboost_ray/tests/test_data_source.py
+++ b/xgboost_ray/tests/test_data_source.py
@@ -7,7 +7,7 @@ import pandas as pd
 import ray
 from ray import ObjectRef
 
-from xgboost_ray.data_sources import Dask, Modin, Partitioned
+from xgboost_ray.data_sources import Dask, Modin, Partitioned, RayDataset
 from xgboost_ray.data_sources.dask import DASK_INSTALLED
 from xgboost_ray.data_sources.modin import MODIN_INSTALLED
 from xgboost_ray.main import _RemoteRayXGBoostActor
@@ -434,6 +434,13 @@ class DaskDataSourceTest(_DistributedDataSourceTest, unittest.TestCase):
 # Ray Datasets data source is not tested, as we do not make use of xgboost-ray
 # partition-to-actor assign logic. Furthermore, xgboost-ray with Ray Datasets
 # is tested in ray-project/ray.
+# The only thing we test here is automatic repartitioning.
+class RayDatasetSourceTest(unittest.TestCase):
+    def testRepartitioning(self):
+        ds = ray.data.from_items([1])
+        assert ds.num_blocks() == 1
+        ds = RayDataset.repartition(ds, 4)
+        assert ds.num_blocks() == 4
 
 
 class PartitionedSourceTest(_DistributedDataSourceTest, unittest.TestCase):

--- a/xgboost_ray/tests/test_data_source.py
+++ b/xgboost_ray/tests/test_data_source.py
@@ -7,7 +7,7 @@ import pandas as pd
 import ray
 from ray import ObjectRef
 
-from xgboost_ray.data_sources import Dask, Modin, Partitioned, RayDataset
+from xgboost_ray.data_sources import Dask, Modin, Partitioned
 from xgboost_ray.data_sources.dask import DASK_INSTALLED
 from xgboost_ray.data_sources.modin import MODIN_INSTALLED
 from xgboost_ray.main import _RemoteRayXGBoostActor
@@ -434,13 +434,6 @@ class DaskDataSourceTest(_DistributedDataSourceTest, unittest.TestCase):
 # Ray Datasets data source is not tested, as we do not make use of xgboost-ray
 # partition-to-actor assign logic. Furthermore, xgboost-ray with Ray Datasets
 # is tested in ray-project/ray.
-# The only thing we test here is automatic repartitioning.
-class RayDatasetSourceTest(unittest.TestCase):
-    def testRepartitioning(self):
-        ds = ray.data.from_items([1])
-        assert ds.num_blocks() == 1
-        ds = RayDataset.repartition(ds, 4)
-        assert ds.num_blocks() == 4
 
 
 class PartitionedSourceTest(_DistributedDataSourceTest, unittest.TestCase):


### PR DESCRIPTION
Currently we throw an error when the number of partitions in a data source is too small for the number of workers.

However, in the case of Ray datasets, we can actually repartition the dataset ourselves.

This will also ensure our quickstart examples, such as in https://docs.ray.io/en/latest/train/train.html#quick-start-to-distributed-training-with-ray-train will work out of the box.

