### PR TITLE
Update CI to use Python 3.8-3.10

### DIFF
--- a/.github/workflows/gpu.yaml
+++ b/.github/workflows/gpu.yaml
@@ -9,10 +9,10 @@ jobs:
     timeout-minutes: 20
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v3
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,10 +12,10 @@ jobs:
     timeout-minutes: 3
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v3
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -34,14 +34,14 @@ jobs:
     timeout-minutes: 160
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10]
         include:
-          - python-version: 3.7
-            ray-wheel: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp37-cp37m-manylinux2014_x86_64.whl
           - python-version: 3.8
             ray-wheel: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl
           - python-version: 3.9
             ray-wheel: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
+          - python-version: 3.10
+            ray-wheel: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp310-cp310-manylinux2014_x86_64.whl
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -78,7 +78,7 @@ jobs:
     timeout-minutes: 160
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -117,7 +117,7 @@ jobs:
     timeout-minutes: 160
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -161,14 +161,14 @@ jobs:
     strategy:
       matrix:
         # no new versions for xgboost are published for 3.6
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10]
         include:
-          - python-version: 3.7
-            ray-wheel: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp37-cp37m-manylinux2014_x86_64.whl
           - python-version: 3.8
             ray-wheel: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl
           - python-version: 3.9
             ray-wheel: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
+          - python-version: 3.10
+            ray-wheel: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp310-cp310-manylinux2014_x86_64.whl
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -223,7 +223,7 @@ jobs:
     timeout-minutes: 160
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.8]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,13 +34,13 @@ jobs:
     timeout-minutes: 160
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10]
+        python-version: ["3.8", "3.9", "3.10"]
         include:
-          - python-version: 3.8
+          - python-version: "3.8"
             ray-wheel: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl
-          - python-version: 3.9
+          - python-version: "3.9"
             ray-wheel: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
-          - python-version: 3.10
+          - python-version: "3.10"
             ray-wheel: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp310-cp310-manylinux2014_x86_64.whl
     steps:
     - uses: actions/checkout@v3
@@ -78,7 +78,7 @@ jobs:
     timeout-minutes: 160
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10]
+        python-version: ["3.8", "3.9", "3.10"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -117,7 +117,7 @@ jobs:
     timeout-minutes: 160
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10]
+        python-version: ["3.8", "3.9", "3.10"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -161,13 +161,13 @@ jobs:
     strategy:
       matrix:
         # no new versions for xgboost are published for 3.6
-        python-version: [3.8, 3.9, 3.10]
+        python-version: ["3.8", "3.9", "3.10"]
         include:
-          - python-version: 3.8
+          - python-version: "3.8"
             ray-wheel: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl
-          - python-version: 3.9
+          - python-version: "3.9"
             ray-wheel: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
-          - python-version: 3.10
+          - python-version: "3.10"
             ray-wheel: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp310-cp310-manylinux2014_x86_64.whl
     steps:
     - uses: actions/checkout@v3

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     "distributed computing framework Ray.",
     url="https://github.com/ray-project/xgboost_ray",
     install_requires=[
-        "ray>=1.10",
+        "ray>=2.0",
         "numpy>=1.16",
         "pandas",
         "wrapt>=1.12.1",

--- a/xgboost_ray/matrix.py
+++ b/xgboost_ray/matrix.py
@@ -85,7 +85,7 @@ def ensure_sorted_by_qid(
         _qid = qid.iloc[:, 0]
     elif isinstance(qid, pd.Series):
         _qid = qid
-    if _qid.is_monotonic:
+    if getattr(_qid, "is_monotonic", False):
         return _qid, df
     else:
         if isinstance(qid, str):

--- a/xgboost_ray/matrix.py
+++ b/xgboost_ray/matrix.py
@@ -85,7 +85,13 @@ def ensure_sorted_by_qid(
         _qid = qid.iloc[:, 0]
     elif isinstance(qid, pd.Series):
         _qid = qid
+    # pandas < 2.0
     if getattr(_qid, "is_monotonic", False):
+        return _qid, df
+    # pandas >= 2.0
+    elif getattr(_qid, "is_monotonic_increasing", False) or getattr(
+        _qid, "is_monotonic_decreasing", False
+    ):
         return _qid, df
     else:
         if isinstance(qid, str):


### PR DESCRIPTION
Python 3.7 is EOL and the Ray OSS CI has switched to Python 3.8 as well.