### PR TITLE
Use new train.report API

### DIFF
--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -2,7 +2,7 @@ packaging
 petastorm
 pytest
 pyarrow
-ray[tune, data]
+ray[tune, data, default]
 scikit-learn
 modin
 dask
@@ -10,4 +10,3 @@ dask
 #workaround for now
 protobuf<4.0.0
 tensorboardX==2.2
-aiohttp

--- a/xgboost_ray/examples/simple_tune.py
+++ b/xgboost_ray/examples/simple_tune.py
@@ -66,7 +66,7 @@ def main(cpus_per_actor, num_actors, num_samples):
 
     # Load the best model checkpoint.
     best_bst = xgboost_ray.tune.load_model(
-        os.path.join(analysis.best_logdir, "tuned.xgb")
+        os.path.join(analysis.best_trial.local_path, "tuned.xgb")
     )
 
     best_bst.save_model("best_model.xgb")

--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -557,7 +557,7 @@ class RayXGBoostActor:
 
         self.checkpoint_frequency = checkpoint_frequency
 
-        self._data: Dict[RayDMatrix, xgb.DMatrix] = {}
+        self._data: Dict[RayDMatrix, dict] = {}
         self._local_n: Dict[RayDMatrix, int] = {}
 
         self._stop_event = stop_event

--- a/xgboost_ray/tests/test_tune.py
+++ b/xgboost_ray/tests/test_tune.py
@@ -158,8 +158,13 @@ class XGBoostRayTuneTest(unittest.TestCase):
 
         replaced = in_dict["callbacks"][0]
         self.assertTrue(isinstance(replaced, TuneReportCheckpointCallback))
-        self.assertSequenceEqual(replaced._report._metrics, ["met"])
-        self.assertEqual(replaced._checkpoint._filename, "test")
+
+        if getattr(replaced, "_report", None):
+            self.assertSequenceEqual(replaced._report._metrics, ["met"])
+            self.assertEqual(replaced._checkpoint._filename, "test")
+        else:
+            self.assertSequenceEqual(replaced._metrics, ["met"])
+            self.assertEqual(replaced._filename, "test")
 
     def testEndToEndCheckpointing(self):
         ray_params = RayParams(cpus_per_actor=1, num_actors=2)

--- a/xgboost_ray/tune.py
+++ b/xgboost_ray/tune.py
@@ -41,9 +41,14 @@ except ImportError:
 
 if TUNE_INSTALLED:
     if hasattr(train, "report"):
-        report = train.report
+
+        def report(**metrics):
+            train.report(metrics)
+
     else:
-        report = tune.report
+
+        def report(**metrics):
+            tune.report(**metrics)
 
     # New style callbacks.
     class TuneReportCallback(OrigTuneReportCallback):

--- a/xgboost_ray/tune.py
+++ b/xgboost_ray/tune.py
@@ -112,10 +112,19 @@ def _try_add_tune_callback(kwargs: Dict):
                 )
                 has_tune_callback = True
             elif isinstance(cb, OrigTuneReportCheckpointCallback):
+                if getattr(cb, "_report", None):
+                    orig_metrics = cb._report._metrics
+                    orig_filename = cb._checkpoint._filename
+                    orig_frequency = cb._checkpoint._frequency
+                else:
+                    orig_metrics = cb._metrics
+                    orig_filename = cb._filename
+                    orig_frequency = cb._frequency
+
                 replace_cb = TuneReportCheckpointCallback(
-                    metrics=cb._report._metrics,
-                    filename=cb._checkpoint._filename,
-                    frequency=cb._checkpoint._frequency,
+                    metrics=orig_metrics,
+                    filename=orig_filename,
+                    frequency=orig_frequency,
                 )
                 new_callbacks.append(replace_cb)
                 logging.warning(


### PR DESCRIPTION
We are converging on using `train.report` throughout the Ray library code base instead of `tune.report`.