### PR TITLE
Simplify checkpointing callback for Ray Train/Tune integration

### DIFF
--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -4,9 +4,10 @@ pytest
 pyarrow
 ray[tune, data, default]
 scikit-learn
-# NOTE: modin==0.23.1.post0 is not compatible with xgboost_ray py38
-#       modin==0.26.0 is not compatible with xgboost_ray py39+
-modin<=0.23.1; python_version=='3.8' or modin<0.26.0; python_version != '3.8'
+# modin==0.23.1.post0 is not compatible with xgboost_ray py38
+modin<=0.23.1; python_version == '3.8'
+# modin==0.26.0 is not compatible with xgboost_ray py39+
+modin<0.26.0; python_version > '3.8'
 dask
 
 #workaround for now

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -1,7 +1,7 @@
 packaging
 petastorm
 pytest
-pyarrow
+pyarrow<15.0.0
 ray[tune, data, default]
 scikit-learn
 # modin==0.23.1.post0 is not compatible with xgboost_ray py38

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -4,7 +4,9 @@ pytest
 pyarrow
 ray[tune, data, default]
 scikit-learn
-modin
+# NOTE: modin==0.23.1.post0 is not compatible with xgboost_ray py38
+#       modin==0.26.0 is not compatible with xgboost_ray py39+
+modin<=0.23.1; python_version=='3.8' or modin<0.26.0; python_version != '3.8'
 dask
 
 #workaround for now

--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -1489,7 +1489,9 @@ def train(
             "order to use xgboost_ray with Tune."
         )
 
-    import ipdb; ipdb.set_trace()
+    import ipdb
+
+    ipdb.set_trace()
     if added_tune_callback or get_current_placement_group():
         # Don't autodetect resources when used with Tune.
         cpus_per_actor = ray_params.cpus_per_actor

--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -98,14 +98,11 @@ RAY_TUNE_INSTALLED = True
 try:
     import ray.train
     import ray.tune
-except (ImportError, ModuleNotFoundError) as e:
+except (ImportError, ModuleNotFoundError):
     RAY_TUNE_INSTALLED = False
 
 if RAY_TUNE_INSTALLED:
-    from xgboost_ray.tune import (
-        _get_tune_resources,
-        _try_add_tune_callback,
-    )
+    from xgboost_ray.tune import _get_tune_resources, _try_add_tune_callback
 else:
     _get_tune_resources = _try_add_tune_callback = None
 

--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -1489,9 +1489,6 @@ def train(
             "order to use xgboost_ray with Tune."
         )
 
-    import ipdb
-
-    ipdb.set_trace()
     if added_tune_callback or get_current_placement_group():
         # Don't autodetect resources when used with Tune.
         cpus_per_actor = ray_params.cpus_per_actor

--- a/xgboost_ray/tests/release/tune_placement.py
+++ b/xgboost_ray/tests/release/tune_placement.py
@@ -20,15 +20,16 @@ hosts actors of the same Ray Tune trial.
 """
 
 import argparse
-from collections import defaultdict
 import json
 import os
 import shutil
 import tempfile
 import time
+from collections import defaultdict
 
 import ray
 import ray.train
+from benchmark_cpu_gpu import train_ray
 from ray import tune
 from ray.tune.integration.docker import DockerSyncer
 from ray.tune.session import get_trial_id
@@ -38,8 +39,6 @@ from xgboost_ray import RayParams
 from xgboost_ray.compat import TrainingCallback
 from xgboost_ray.session import put_queue
 from xgboost_ray.tests.utils import create_parquet
-
-from benchmark_cpu_gpu import train_ray
 
 if "OMP_NUM_THREADS" in os.environ:
     del os.environ["OMP_NUM_THREADS"]

--- a/xgboost_ray/tests/release/tune_placement.py
+++ b/xgboost_ray/tests/release/tune_placement.py
@@ -1,4 +1,6 @@
 """
+NOTE: This example is currently broken (very outdated) and not run in CI.
+
 Test Ray Tune trial placement across cluster nodes.
 
 Example: Run this script on a cluster with 4 workers nodes a 4 CPUs.

--- a/xgboost_ray/tests/test_client.py
+++ b/xgboost_ray/tests/test_client.py
@@ -21,6 +21,14 @@ def start_client_server_5_cpus():
         yield client
 
 
+@pytest.fixture
+def start_client_server_5_cpus_modin(monkeypatch):
+    monkeypatch.setenv("__MODIN_AUTOIMPORT_PANDAS__", "1")
+    ray.init(num_cpus=5, runtime_env={"env_vars": {"__MODIN_AUTOIMPORT_PANDAS__": "1"}})
+    with ray_start_client_server() as client:
+        yield client
+
+
 def test_simple_train(start_client_server_4_cpus):
     assert ray.util.client.ray.is_connected()
     from xgboost_ray.examples.simple import main
@@ -43,7 +51,7 @@ def test_simple_dask(start_client_server_5_cpus):
     main(cpus_per_actor=1, num_actors=4)
 
 
-def test_simple_modin(start_client_server_5_cpus):
+def test_simple_modin(start_client_server_5_cpus_modin):
     assert ray.util.client.ray.is_connected()
     from xgboost_ray.examples.simple_modin import main
 

--- a/xgboost_ray/tests/test_tune.py
+++ b/xgboost_ray/tests/test_tune.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import tempfile
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import ray
@@ -83,7 +83,9 @@ class XGBoostRayTuneTest(unittest.TestCase):
         # TODO(justinvyu): Remove this once the xgboost integration
         # has been updated on the Ray side.
         try:
-            callback = TuneReportCheckpointCallback(frequency=1, checkpoint_at_end=False)
+            callback = TuneReportCheckpointCallback(
+                frequency=1, checkpoint_at_end=False
+            )
         except TypeError:
             callback = TuneReportCheckpointCallback(frequency=1)
 

--- a/xgboost_ray/tests/test_tune.py
+++ b/xgboost_ray/tests/test_tune.py
@@ -79,13 +79,16 @@ class XGBoostRayTuneTest(unittest.TestCase):
         ray_params = RayParams(cpus_per_actor=1, num_actors=2)
         params = self.params.copy()
         params["num_boost_round"] = tune.grid_search([1, 3])
+
+        # TODO(justinvyu): Remove this once the xgboost integration
+        # has been updated on the Ray side.
+        try:
+            callback = TuneReportCheckpointCallback(frequency=1, checkpoint_at_end=False)
+        except TypeError:
+            callback = TuneReportCheckpointCallback(frequency=1)
+
         analysis = tune.run(
-            self.train_func(
-                ray_params,
-                callbacks=[
-                    TuneReportCheckpointCallback(frequency=1, checkpoint_at_end=False)
-                ],
-            ),
+            self.train_func(ray_params, callbacks=[callback]),
             config=self.params,
             resources_per_trial=ray_params.get_tune_resources(),
             num_samples=1,

--- a/xgboost_ray/tests/test_tune.py
+++ b/xgboost_ray/tests/test_tune.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import tempfile
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 import numpy as np
 import ray
@@ -140,7 +140,7 @@ class XGBoostRayTuneTest(unittest.TestCase):
         in_dict = {"callbacks": in_cp}
 
         with patch("ray.train.get_context") as mocked:
-            mocked.return_value = True
+            mocked.return_value = MagicMock(return_value=True)
             _try_add_tune_callback(in_dict)
 
         replaced = in_dict["callbacks"][0]

--- a/xgboost_ray/tests/test_tune.py
+++ b/xgboost_ray/tests/test_tune.py
@@ -18,13 +18,6 @@ from xgboost_ray.tune import (
     _try_add_tune_callback,
 )
 
-try:
-    from ray.air import Checkpoint
-except Exception:
-
-    class Checkpoint:
-        pass
-
 
 class XGBoostRayTuneTest(unittest.TestCase):
     def setUp(self):

--- a/xgboost_ray/tests/test_tune.py
+++ b/xgboost_ray/tests/test_tune.py
@@ -13,10 +13,7 @@ from ray.tune.integration.xgboost import (
 )
 
 from xgboost_ray import RayDMatrix, RayParams, train
-from xgboost_ray.tune import (
-    TuneReportCheckpointCallback,
-    _try_add_tune_callback,
-)
+from xgboost_ray.tune import TuneReportCheckpointCallback, _try_add_tune_callback
 
 
 class XGBoostRayTuneTest(unittest.TestCase):

--- a/xgboost_ray/tune.py
+++ b/xgboost_ray/tune.py
@@ -77,19 +77,11 @@ def _try_add_tune_callback(kwargs: Dict):
                 has_tune_callback = True
                 new_callbacks.append(cb)
             elif isinstance(cb, OrigTuneReportCheckpointCallback):
-                if getattr(cb, "_report", None):
-                    orig_metrics = cb._report._metrics
-                    orig_filename = cb._checkpoint._filename
-                    orig_frequency = cb._checkpoint._frequency
-                else:
-                    orig_metrics = cb._metrics
-                    orig_filename = cb._filename
-                    orig_frequency = cb._frequency
+                orig_metrics = cb._metrics
+                orig_frequency = cb._frequency
 
                 replace_cb = TuneReportCheckpointCallback(
-                    metrics=orig_metrics,
-                    filename=orig_filename,
-                    frequency=orig_frequency,
+                    metrics=orig_metrics, frequency=orig_frequency
                 )
                 new_callbacks.append(replace_cb)
                 logging.warning(

--- a/xgboost_ray/tune.py
+++ b/xgboost_ray/tune.py
@@ -17,9 +17,7 @@ except (ImportError, ModuleNotFoundError) as e:
     ) from e
 
 import ray.train
-from ray.tune.integration.xgboost import (
-    TuneReportCallback as OrigTuneReportCallback,
-)
+from ray.tune.integration.xgboost import TuneReportCallback as OrigTuneReportCallback
 from ray.tune.integration.xgboost import (
     TuneReportCheckpointCallback as OrigTuneReportCheckpointCallback,
 )

--- a/xgboost_ray/tune.py
+++ b/xgboost_ray/tune.py
@@ -121,11 +121,6 @@ def _get_tune_resources(
     bundles = [head_bundle] + child_bundles
     placement_options = placement_options or {}
     placement_options.setdefault("strategy", "PACK")
-    # Special case, same as in
-    # ray.air.ScalingConfig.as_placement_group_factory
-    # TODO remove after Ray 2.3 is out
-    if placement_options.get("_max_cpu_fraction_per_node", None) is None:
-        placement_options.pop("_max_cpu_fraction_per_node", None)
     placement_group_factory = PlacementGroupFactory(bundles, **placement_options)
 
     return placement_group_factory

--- a/xgboost_ray/tune.py
+++ b/xgboost_ray/tune.py
@@ -1,92 +1,67 @@
-# Tune imports.
 import logging
 from typing import Dict, Optional
 
 import ray
-from ray.train._internal.session import get_session
 from ray.util.annotations import PublicAPI
 
 from xgboost_ray.session import get_rabit_rank, put_queue
-from xgboost_ray.util import Unavailable, force_on_current_node
+from xgboost_ray.util import force_on_current_node
 from xgboost_ray.xgb import xgboost as xgb
 
 try:
-    from ray import train, tune
-    from ray.tune import is_session_enabled
-    from ray.tune.integration.xgboost import (
-        TuneReportCallback as OrigTuneReportCallback,
-    )
-    from ray.tune.integration.xgboost import (
-        TuneReportCheckpointCallback as OrigTuneReportCheckpointCallback,
-    )
-    from ray.tune.integration.xgboost import (
-        _TuneCheckpointCallback as _OrigTuneCheckpointCallback,
-    )
-    from ray.tune.utils import flatten_dict
+    from ray import train, tune  # noqa: F401
+except (ImportError, ModuleNotFoundError) as e:
+    raise RuntimeError(
+        "Ray Train and Ray Tune are required dependencies of xgboost_ray. "
+        'Please install with: `pip install "ray[train]"`'
+    ) from e
 
-    TUNE_INSTALLED = True
-except ImportError:
-    tune = None
-    TuneReportCallback = (
-        _TuneCheckpointCallback
-    ) = TuneReportCheckpointCallback = Unavailable
-    OrigTuneReportCallback = (
-        _OrigTuneCheckpointCallback
-    ) = OrigTuneReportCheckpointCallback = object
-
-    def is_session_enabled():
-        return False
-
-    flatten_dict = is_session_enabled
-    TUNE_INSTALLED = False
+import ray.train
+from ray.tune.integration.xgboost import (
+    TuneReportCallback as OrigTuneReportCallback,
+)
+from ray.tune.integration.xgboost import (
+    TuneReportCheckpointCallback as OrigTuneReportCheckpointCallback,
+)
 
 
-if TUNE_INSTALLED:
-    if not hasattr(train, "report"):
+class TuneReportCheckpointCallback(OrigTuneReportCheckpointCallback):
+    def after_iteration(self, model, epoch: int, evals_log: Dict):
+        # NOTE: We need to update `evals_log` here (even though the super method
+        # already does it) because the actual callback method gets run
+        # in a different process, so *this* instance of the callback will not have
+        # access to the `evals_log` dict in `after_training`.
+        self._evals_log = evals_log
 
-        # New style callbacks.
-        class TuneReportCallback(OrigTuneReportCallback):
-            def after_iteration(self, model, epoch: int, evals_log: Dict):
-                if get_rabit_rank() == 0:
-                    report_dict = self._get_report_dict(evals_log)
-                    put_queue(lambda: tune.report(**report_dict))
+        if get_rabit_rank() == 0:
+            put_queue(
+                lambda: super(TuneReportCheckpointCallback, self).after_iteration(
+                    model=model, epoch=epoch, evals_log=evals_log
+                )
+            )
 
-        class _TuneCheckpointCallback(_OrigTuneCheckpointCallback):
-            def after_iteration(self, model, epoch: int, evals_log: Dict):
-                if get_rabit_rank() == 0:
-                    put_queue(
-                        lambda: self._create_checkpoint(
-                            model, epoch, self._filename, self._frequency
-                        )
-                    )
+    def after_training(self, model):
+        if get_rabit_rank() == 0:
+            put_queue(
+                lambda: super(TuneReportCheckpointCallback, self).after_training(
+                    model=model
+                )
+            )
+        return model
 
-        class TuneReportCheckpointCallback(OrigTuneReportCheckpointCallback):
-            _checkpoint_callback_cls = _TuneCheckpointCallback
-            _report_callbacks_cls = TuneReportCallback
 
-    else:
-
-        class TuneReportCheckpointCallback(OrigTuneReportCheckpointCallback):
-            def after_iteration(self, model, epoch: int, evals_log: Dict):
-                if get_rabit_rank() == 0:
-                    put_queue(
-                        lambda: super(
-                            TuneReportCheckpointCallback, self
-                        ).after_iteration(model=model, epoch=epoch, evals_log=evals_log)
-                    )
-
-        class TuneReportCallback(OrigTuneReportCallback):
-            def after_iteration(self, model, epoch: int, evals_log: Dict):
-                if get_rabit_rank() == 0:
-                    put_queue(
-                        lambda: super(TuneReportCallback, self).after_iteration(
-                            model=model, epoch=epoch, evals_log=evals_log
-                        )
-                    )
+class TuneReportCallback(OrigTuneReportCallback):
+    def __new__(cls: type, *args, **kwargs):
+        # TODO(justinvyu): [code_removal] Remove in Ray 2.11.
+        raise DeprecationWarning(
+            "`TuneReportCallback` is deprecated. "
+            "Use `xgboost_ray.tune.TuneReportCheckpointCallback` instead."
+        )
 
 
 def _try_add_tune_callback(kwargs: Dict):
-    if TUNE_INSTALLED and (is_session_enabled() or get_session()):
+    ray_train_context_initialized = bool(ray.train.get_context())
+    if ray_train_context_initialized:
         callbacks = kwargs.get("callbacks", []) or []
         new_callbacks = []
         has_tune_callback = False
@@ -98,19 +73,9 @@ def _try_add_tune_callback(kwargs: Dict):
         )
 
         for cb in callbacks:
-            if isinstance(cb, (TuneReportCallback, TuneReportCheckpointCallback)):
+            if isinstance(cb, TuneReportCheckpointCallback):
                 has_tune_callback = True
                 new_callbacks.append(cb)
-            elif isinstance(cb, OrigTuneReportCallback):
-                replace_cb = TuneReportCallback(metrics=cb._metrics)
-                new_callbacks.append(replace_cb)
-                logging.warning(
-                    REPLACE_MSG.format(
-                        orig="ray.tune.integration.xgboost.TuneReportCallback",
-                        target="xgboost_ray.tune.TuneReportCallback",
-                    )
-                )
-                has_tune_callback = True
             elif isinstance(cb, OrigTuneReportCheckpointCallback):
                 if getattr(cb, "_report", None):
                     orig_metrics = cb._report._metrics
@@ -139,8 +104,7 @@ def _try_add_tune_callback(kwargs: Dict):
                 new_callbacks.append(cb)
 
         if not has_tune_callback:
-            # Todo: Maybe add checkpointing callback
-            new_callbacks.append(TuneReportCallback())
+            new_callbacks.append(TuneReportCheckpointCallback(frequency=0))
 
         kwargs["callbacks"] = new_callbacks
         return True
@@ -156,32 +120,23 @@ def _get_tune_resources(
     placement_options: Optional[Dict],
 ):
     """Returns object to use for ``resources_per_trial`` with Ray Tune."""
-    if TUNE_INSTALLED:
-        from ray.tune import PlacementGroupFactory
+    from ray.tune import PlacementGroupFactory
 
-        head_bundle = {}
-        child_bundle = {"CPU": cpus_per_actor, "GPU": gpus_per_actor}
-        child_bundle_extra = {} if resources_per_actor is None else resources_per_actor
-        child_bundles = [
-            {**child_bundle, **child_bundle_extra} for _ in range(num_actors)
-        ]
-        bundles = [head_bundle] + child_bundles
-        placement_options = placement_options or {}
-        placement_options.setdefault("strategy", "PACK")
-        # Special case, same as in
-        # ray.air.ScalingConfig.as_placement_group_factory
-        # TODO remove after Ray 2.3 is out
-        if placement_options.get("_max_cpu_fraction_per_node", None) is None:
-            placement_options.pop("_max_cpu_fraction_per_node", None)
-        placement_group_factory = PlacementGroupFactory(bundles, **placement_options)
+    head_bundle = {}
+    child_bundle = {"CPU": cpus_per_actor, "GPU": gpus_per_actor}
+    child_bundle_extra = {} if resources_per_actor is None else resources_per_actor
+    child_bundles = [{**child_bundle, **child_bundle_extra} for _ in range(num_actors)]
+    bundles = [head_bundle] + child_bundles
+    placement_options = placement_options or {}
+    placement_options.setdefault("strategy", "PACK")
+    # Special case, same as in
+    # ray.air.ScalingConfig.as_placement_group_factory
+    # TODO remove after Ray 2.3 is out
+    if placement_options.get("_max_cpu_fraction_per_node", None) is None:
+        placement_options.pop("_max_cpu_fraction_per_node", None)
+    placement_group_factory = PlacementGroupFactory(bundles, **placement_options)
 
-        return placement_group_factory
-    else:
-        raise RuntimeError(
-            "Tune is not installed, so `get_tune_resources` is "
-            "not supported. You can install Ray Tune via `pip "
-            "install ray[tune]`."
-        )
+    return placement_group_factory
 
 
 @PublicAPI(stability="beta")

--- a/xgboost_ray/tune.py
+++ b/xgboost_ray/tune.py
@@ -58,7 +58,9 @@ class TuneReportCallback(OrigTuneReportCallback):
 
 
 def _try_add_tune_callback(kwargs: Dict):
-    ray_train_context_initialized = bool(ray.train.get_context())
+    ray_train_context_initialized = (
+        ray.train.get_context().get_trial_resources() is not None
+    )
     if ray_train_context_initialized:
         callbacks = kwargs.get("callbacks", []) or []
         new_callbacks = []


### PR DESCRIPTION
This PR simplifies the Ray Train/Tune integration for `xgboost_ray` by doing the following:
* Removes the deprecated APIs (`TuneReportCallback`, `is_session_enabled`, `callback._report`, `callback._checkpoint`)
* Unifies the checkpointing integration with Tune around `TuneReportCheckpointCallback`
* Uses the public `ray.train.get_context` API instead of detecting the train "session"
* Preps this repository to be merged into the main Ray repo.

See the corresponding Ray changes: https://github.com/ray-project/ray/pull/42111