### PR TITLE
Add multi label support v2

### DIFF
--- a/xgboost_ray/data_sources/data_source.py
+++ b/xgboost_ray/data_sources/data_source.py
@@ -123,7 +123,7 @@ class DataSource:
 
         This method should usually not be overwritten.
         """
-        if isinstance(column, str):
+        if isinstance(column, str) or isinstance(column, List):
             return data[column], column
         elif column is not None:
             return cls.convert_to_series(column), None

--- a/xgboost_ray/data_sources/data_source.py
+++ b/xgboost_ray/data_sources/data_source.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import pandas as pd
 from ray.actor import ActorHandle
@@ -118,7 +118,7 @@ class DataSource:
     @classmethod
     def get_column(
         cls, data: pd.DataFrame, column: Any
-    ) -> Tuple[pd.Series, Optional[str]]:
+    ) -> Tuple[pd.Series, Optional[Union[str, List]]]:
         """Helper method wrapping around convert to series.
 
         This method should usually not be overwritten.

--- a/xgboost_ray/matrix.py
+++ b/xgboost_ray/matrix.py
@@ -411,9 +411,9 @@ class _CentralRayDMatrixLoader(_RayDMatrixLoader):
             # We have to make sure they are compatible
             # if it's a parquet data source and label is a list,
             # then we consider it a multi-label data
-            if not data_source.is_data_type(self.label) \
-                and not (isinstance(self.label, List) \
-                and data_source.__name__ == "Parquet"):
+            if not data_source.is_data_type(self.label) and not (
+                isinstance(self.label, List) and data_source.__name__ == "Parquet"
+            ):
                 raise ValueError(
                     "The passed `data` and `label` types are not compatible."
                     "\nFIX THIS by passing the same types to the "

--- a/xgboost_ray/matrix.py
+++ b/xgboost_ray/matrix.py
@@ -528,7 +528,11 @@ class _DistributedRayDMatrixLoader(_RayDMatrixLoader):
                 f"RayDMatrix."
             )
 
-        if self.label is not None and not isinstance(self.label, str) and not isinstance(self.label, List):
+        if (
+            self.label is not None
+            and not isinstance(self.label, str)
+            and not isinstance(self.label, List)
+        ):
             raise ValueError(
                 f"Invalid `label` value for distributed datasets: "
                 f"{self.label}. Only strings are supported. "

--- a/xgboost_ray/matrix.py
+++ b/xgboost_ray/matrix.py
@@ -307,7 +307,10 @@ class _RayDMatrixLoader:
 
         label, exclude = data_source.get_column(local_data, self.label)
         if exclude:
-            exclude_cols.add(exclude)
+            if isinstance(exclude, List):
+                exclude_cols.update(exclude)
+            else:
+                exclude_cols.add(exclude)
 
         weight, exclude = data_source.get_column(local_data, self.weight)
         if exclude:
@@ -406,7 +409,11 @@ class _CentralRayDMatrixLoader(_RayDMatrixLoader):
         ):  # noqa: E721:
             # Label is an object of a different type than the main data.
             # We have to make sure they are compatible
-            if not data_source.is_data_type(self.label):
+            # if it's a parquet data source and label is a list,
+            # then we consider it a multi-label data
+            if not data_source.is_data_type(self.label) \
+                and not (isinstance(self.label, List) \
+                and data_source.__name__ == "Parquet"):
                 raise ValueError(
                     "The passed `data` and `label` types are not compatible."
                     "\nFIX THIS by passing the same types to the "

--- a/xgboost_ray/matrix.py
+++ b/xgboost_ray/matrix.py
@@ -528,7 +528,7 @@ class _DistributedRayDMatrixLoader(_RayDMatrixLoader):
                 f"RayDMatrix."
             )
 
-        if self.label is not None and not isinstance(self.label, str):
+        if self.label is not None and not isinstance(self.label, str) and not isinstance(self.label, List):
             raise ValueError(
                 f"Invalid `label` value for distributed datasets: "
                 f"{self.label}. Only strings are supported. "

--- a/xgboost_ray/tests/test_matrix.py
+++ b/xgboost_ray/tests/test_matrix.py
@@ -71,7 +71,7 @@ class XGBoostRayDMatrixTest(unittest.TestCase):
 
         assert data.columns.tolist() == cols[:-1]
 
-    def _testMatrixCreation(self, in_x, in_y, multi_label = False, **kwargs):
+    def _testMatrixCreation(self, in_x, in_y, multi_label=False, **kwargs):
         if "sharding" not in kwargs:
             kwargs["sharding"] = RayShardingMode.BATCH
         mat = RayDMatrix(in_x, in_y, **kwargs)
@@ -300,8 +300,12 @@ class XGBoostRayDMatrixTest(unittest.TestCase):
             data_df[labels] = self.multi_y
             data_df.to_parquet(data_file)
 
-            self._testMatrixCreation(data_file, labels, multi_label=True, distributed=False)
-            self._testMatrixCreation(data_file, labels, multi_label=True, distributed=True)
+            self._testMatrixCreation(
+                data_file, labels, multi_label=True, distributed=False
+            )
+            self._testMatrixCreation(
+                data_file, labels, multi_label=True, distributed=True
+            )
 
     def testFromParquetString(self):
         with tempfile.TemporaryDirectory() as dir:
@@ -313,7 +317,7 @@ class XGBoostRayDMatrixTest(unittest.TestCase):
 
             self._testMatrixCreation(data_file, "label", distributed=False)
             self._testMatrixCreation(data_file, "label", distributed=True)
-            
+
     def testFromMultiParquetStringMultiLabel(self):
         with tempfile.TemporaryDirectory() as dir:
             data_file_1 = os.path.join(dir, "data_1.parquet")


### PR DESCRIPTION
This is a new pull request to replace https://github.com/ray-project/xgboost_ray/pull/298 because I'm unable to work on that branch.

I copied content from that pull requests:
Hi I added support to allow label as a list. So we can support reading data with multiple labels. This can then solve https://github.com/ray-project/xgboost_ray/issues/286.
I verified new unit tests pass. Also test_matrix.py all pass with my local set up.
I verified locally by training a xgboost model with parquet data format, it works well. So far it should work well for parquet data format. Thank you!

I verified the change works with the blow code example:

```
from sklearn.datasets import make_multilabel_classification
import pandas as pd
import numpy as np
n_classes = 5
random_state = 0
X, y = make_multilabel_classification(n_samples=32, n_classes=5, n_labels=3, random_state=random_state)
features = [f"f{i}" for i in range(len(X[0]))]
labels = [f"label_{i}" for i in range(n_classes)]

X_df = pd.DataFrame(X, columns = features)
y_df = pd.DataFrame(y, columns = labels)
data = pd.concat([X_df, y_df], axis = 1)

data.to_parquet("~/Desktop/sample_data/data.parquet")

from xgboost_ray import RayDMatrix, RayParams, train, RayFileType
n_classes = 5
features = [f"f{i}" for i in range(20)]

labels = [f"label_{i}" for i in range(n_classes)]

training_data = "~/Desktop/sample_data"
train_set = RayDMatrix(training_data, labels, columns = features + labels, filetype=RayFileType.PARQUET)

evals_result = {}
bst = train(
    {
        "objective": "binary:logistic",
        "eval_metric": ["logloss", "error"],
        "random_state": random_state,
    },
    train_set,
    num_boost_round = 1,
    evals_result=evals_result,
    evals=[(train_set, "train")],
    verbose_eval=False,
    ray_params=RayParams(
        num_actors=1,  # Number of remote actors
        cpus_per_actor=1))

#bst.save_model("model.xgb")
#print("Final training error: {:.4f}".format(
#    evals_result["train"]["error"][-1]))

from xgboost_ray import predict
pred_ray = predict(bst, train_set, ray_params=RayParams(num_actors=1))
print(pred_ray)


import xgboost as xgb

clf = xgb.XGBClassifier(tree_method="hist", n_estimators = 1, random_state=0)
clf.fit(X, y)
expected = clf.predict_proba(X)

np.testing.assert_allclose(expected, pred_ray)

```
