### PR TITLE
[Data] Remove `Dataset.num_blocks()` usages

### DIFF
--- a/xgboost_ray/data_sources/ray_dataset.py
+++ b/xgboost_ray/data_sources/ray_dataset.py
@@ -107,4 +107,4 @@ class RayDataset(DataSource):
         """
         Return number of distributed blocks.
         """
-        return data.num_blocks()
+        return data._plan.initial_num_blocks()


### PR DESCRIPTION
As part of https://github.com/ray-project/ray/pull/43178, we want to remove all usages of `Dataset.num_blocks()`, as that method will be deprecated for Ray 2.10.