### PR TITLE
Fix compatibility with xgboost  2.1.0

### DIFF
--- a/xgboost_ray/main.py
+++ b/xgboost_ray/main.py
@@ -272,7 +272,8 @@ def _start_rabit_tracker(num_workers: int):
 
     env = {"DMLC_NUM_WORKER": num_workers}
 
-    rabit_tracker = _RabitTracker(host, num_workers)
+    # Name arguments, to ensure compatability with newer xgboost versions
+    rabit_tracker = _RabitTracker(host_ip=host, n_workers=num_workers)
 
     # Get tracker Host + IP
     env.update(rabit_tracker.worker_envs())


### PR DESCRIPTION
In xgboost 2.0.3 the arguments to RabitTracker are in the order `host_ip`, `n_workers` (https://github.com/dmlc/xgboost/blob/v2.0.3/python-package/xgboost/tracker.py#L183) but in the latest xgboost (2.1.0) the arguments have been swapped around: https://github.com/dmlc/xgboost/blob/v2.1.0/python-package/xgboost/tracker.py#L53

This causes errors when using this package, as it defines no upper bound for the xgboost version: https://github.com/ray-project/xgboost_ray/blob/master/setup.py#L18 

This PR aims to solve that problem and maintain compatability but naming the arguments